### PR TITLE
fix: export ErrorCode as runtime value

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 [![npm version](https://img.shields.io/npm/v/bun-ws-router.svg)](https://www.npmjs.com/package/bun-ws-router)
 [![npm downloads](https://img.shields.io/npm/dm/bun-ws-router.svg)](https://www.npmjs.com/package/bun-ws-router)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/bun-ws-router)](https://bundlephobia.com/package/bun-ws-router)
-[![license](https://img.shields.io/npm/l/bun-ws-router.svg)](https://github.com/kriasoft/bun-ws-router/blob/main/LICENSE)
 [![GitHub Actions](https://github.com/kriasoft/bun-ws-router/actions/workflows/main.yml/badge.svg)](https://github.com/kriasoft/bun-ws-router/actions)
+[![Chat on Discord](https://img.shields.io/discord/643523529131950086?label=Discord)](https://discord.com/invite/aW29wXyb7w)
 
 Tired of wrestling WebSocket connections like a tangled mess of holiday lights? `bun-ws-router` is here to bring order to the chaos! It's a type-safe WebSocket router for Bun, powered by **Zod** or **Valibot** validation, making your real-time message handling smoother than a fresh jar of peanut butter. Route WebSocket messages to handlers based on message type with full TypeScript support.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bun-ws-router",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A simple and efficient WebSocket router for Bun with Zod/Valibot message validation.",
   "keywords": [
     "broadcast",
@@ -25,7 +25,7 @@
     "ws",
     "zod"
   ],
-  "homepage": "https://github.com/kriasoft/bun-ws-router",
+  "homepage": "https://kriasoft.com/bun-ws-router/",
   "bugs": "https://github.com/kriasoft/bun-ws-router/issues",
   "repository": {
     "type": "git",

--- a/zod/index.ts
+++ b/zod/index.ts
@@ -7,6 +7,7 @@ export {
   ErrorMessage,
   MessageSchema,
   MessageMetadataSchema,
+  ErrorCode,
 } from "./schema";
 export { publish } from "./publish";
 export type {
@@ -23,4 +24,3 @@ export type {
   CloseHandlerContext,
   CloseHandler,
 } from "./types";
-export type { ErrorCode } from "./schema";


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where `ErrorCode` was exported as type-only, preventing runtime usage of the enum values.

## The Problem

The `ErrorCode` enum was incorrectly exported using `export type`, which made it unavailable at runtime. This prevented developers from using the enum values in their code:

```typescript
// This would fail with "Cannot read properties of undefined"
import { ErrorCode } from 'bun-ws-router';

ctx.send(ErrorMessage, {
  code: ErrorCode.AUTHENTICATION_FAILED, // Runtime error\!
  message: "Invalid token"
});
```

## The Solution

Changed the export from type-only to a regular export, making the enum available at runtime:

```diff
- export type { ErrorCode } from "./schema";
+ export { ErrorCode } from "./schema";
```

## Testing

- Verified that `ErrorCode` enum values are now accessible at runtime
- All existing tests pass
- Integration tests confirm the fix works correctly

## Impact

This is a bug fix that restores intended functionality. Users can now properly use the `ErrorCode` enum as documented.