### PR TITLE
fix: improve type safety for MessageContext payload handling

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+## Our Commitment
+
+We're building bun-ws-router to be useful, reliable, and accessible to everyone. We want our community to reflect those same values.
+
+## Expected Behavior
+
+- **Be respectful**: Different perspectives make us stronger
+- **Be constructive**: Focus on solutions and learning
+- **Be patient**: Everyone starts somewhere
+- **Be inclusive**: Welcome newcomers and diverse backgrounds
+- **Be collaborative**: We're all here to build something useful together
+
+## Unacceptable Behavior
+
+- Harassment, discrimination, or personal attacks
+- Trolling, insulting comments, or deliberate disruption
+- Publishing private information without permission
+- Any conduct that would be inappropriate in a professional setting
+
+## Enforcement
+
+Issues can be reported to:
+
+- **Project maintainers**: Open an issue or discussion
+- **Private concerns**: Email security@kriasoft.com
+
+We'll respond promptly and fairly. Consequences may include warnings, temporary restrictions, or permanent bans depending on severity.
+
+## Scope
+
+This applies to all project spaces: GitHub repositories, discussions, and any bun-ws-router-related communications.
+
+---
+
+_Adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), focused on practical collaboration._

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing to bun-ws-router
+
+Thanks for your interest in contributing! This guide will help you get started.
+
+## Prerequisites
+
+- **Bun**: Install from [bun.sh](https://bun.sh)
+
+## Quick Start
+
+1. **Fork and clone**:
+
+   ```bash
+   git clone https://github.com/your-username/bun-ws-router.git
+   cd bun-ws-router
+   ```
+
+2. **Install dependencies**:
+
+   ```bash
+   bun install
+   ```
+
+3. **Run tests**:
+
+   ```bash
+   bun test
+   ```
+
+## Development Workflow
+
+### Making Changes
+
+1. **Create a feature branch**:
+
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+2. **Write your code** following existing patterns
+3. **Add tests** for new functionality
+4. **Run checks**:
+
+   ```bash
+   bun run typecheck   # Type checking
+   bun run format      # Auto-format code
+   bun test            # Run tests
+   ```
+
+### Code Standards
+
+- **TypeScript**: Strict mode with full type safety
+- **Formatting**: Prettier (auto-runs on commit via lint-staged)
+- **Linting**: ESLint with unused directive checks
+- **Exports**: Named exports, tree-shakable modules
+- **Tests**: Cover new functionality and edge cases
+
+## Submitting Changes
+
+1. **Commit your changes**:
+
+   ```bash
+   git add .
+   git commit -m "Add your feature description"
+   ```
+
+   Pre-commit hooks will format code and run type checks.
+
+2. **Push and create PR**:
+
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+3. **PR checklist**:
+   - [ ] Tests pass locally
+   - [ ] Code is formatted (automatic via hooks)
+   - [ ] TypeScript compiles without errors
+   - [ ] New functionality has tests
+
+## Project Structure
+
+```
+shared/             # Core types and utilities
+zod/                # Zod adapter implementation
+valibot/            # Valibot adapter implementation
+index.ts            # Main router exports
+test/               # Test files
+docs/               # VitePress documentation site
+specs/              # Technical specifications and ADRs
+```
+
+## Types of Contributions
+
+- **Bug fixes**: Include test case demonstrating the bug
+- **New features**: Discuss approach first in an issue
+- **Performance improvements**: Include benchmarks when relevant
+- **Documentation**: Examples, edge cases, and troubleshooting
+- **Tests**: Better coverage is always welcome
+
+## Design Principles
+
+Follow these key principles:
+
+- **Prioritize optimal design over backwards compatibility**
+- **Keep it simple** - avoid over-engineering
+- **Design APIs that are predictable, composable, and hard to misuse**
+- **Pay attention to developer experience**
+- **Pay attention to performance**
+
+## Getting Help
+
+- **Questions**: Open a [discussion](https://github.com/kriasoft/bun-ws-router/discussions)
+- **Bugs**: Check [existing issues](https://github.com/kriasoft/bun-ws-router/issues) first
+- **Documentation**: See [docs site](https://kriasoft.com/bun-ws-router/)
+
+## Code of Conduct
+
+Be respectful, inclusive, and constructive. We're all here to build something useful together.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.4.x   | :white_check_mark: |
+| < 0.4   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in bun-ws-router, please report it responsibly:
+
+**DO NOT** open a public issue for security vulnerabilities.
+
+Instead, please email: security@kriasoft.com
+
+Include in your report:
+
+- Description of the vulnerability
+- Steps to reproduce (if applicable)
+- Potential impact
+- Suggested fix (if you have one)
+
+## Response Timeline
+
+- **Acknowledgment**: Within 48 hours
+- **Initial assessment**: Within 1 week
+- **Fix timeline**: Depends on severity
+
+## Security Considerations
+
+When using bun-ws-router:
+
+- **Input validation**: Always validate incoming WebSocket messages with schema validation (Zod/Valibot)
+- **Authentication**: Implement proper authentication during WebSocket upgrade
+- **Authorization**: Verify user permissions in message handlers via `ctx.ws.data`
+- **Rate limiting**: Implement rate limiting to prevent abuse
+- **Message size limits**: Configure appropriate message size limits in Bun.serve
+- **Dependencies**: Keep dependencies updated to prevent supply chain attacks
+
+## Disclosure Policy
+
+- Vulnerabilities will be disclosed publicly after fixes are available
+- Credit will be given to security researchers (with permission)
+- CVE numbers will be requested for significant vulnerabilities
+
+## Responsible Disclosure
+
+We appreciate security researchers who help keep bun-ws-router secure. If you report a valid security issue, we'll acknowledge your contribution in the release notes (with your permission) and coordinate disclosure timing with you.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependabot configuration for automated dependency updates
+# Creates weekly PRs with all dependency updates grouped together
+# https://docs.github.com/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
+version: 2
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    versioning-strategy: "increase-if-necessary"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+        # Allow security updates to be created separately
+        applies-to: version-updates

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+bunx lint-staged

--- a/bun.lock
+++ b/bun.lock
@@ -4,25 +4,27 @@
     "": {
       "name": "bun-ws-router",
       "dependencies": {
-        "uuid": "^11.1.0",
+        "uuid": "^13.0.0",
       },
       "devDependencies": {
-        "@eslint/js": "^9.34.0",
-        "@types/bun": "^1.2.21",
-        "eslint": "^9.34.0",
+        "@eslint/js": "^9.36.0",
+        "@types/bun": "^1.2.23",
+        "eslint": "^9.36.0",
         "eslint-config-prettier": "^10.1.8",
-        "globals": "^16.3.0",
-        "hono": "^4.9.6",
-        "jiti": "^2.5.1",
+        "globals": "^16.4.0",
+        "hono": "^4.9.9",
+        "husky": "^9.1.7",
+        "jiti": "^2.6.1",
+        "lint-staged": "^16.2.3",
         "prettier": "^3.6.2",
-        "typescript": "^5.9.2",
-        "typescript-eslint": "^8.42.0",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.45.0",
         "valibot": "^1.1.0",
         "vitepress": "^1.6.4",
-        "zod": "^4.1.5",
+        "zod": "^4.1.11",
       },
       "peerDependencies": {
-        "@types/bun": ">=1.1.0",
+        "@types/bun": ">1.2.23",
         "valibot": ">=1.1.0",
         "zod": ">=4.0.14",
       },
@@ -141,7 +143,7 @@
 
     "@eslint/eslintrc": ["@eslint/eslintrc@3.3.1", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ=="],
 
-    "@eslint/js": ["@eslint/js@9.34.0", "", {}, "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw=="],
+    "@eslint/js": ["@eslint/js@9.36.0", "", {}, "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw=="],
 
     "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
 
@@ -225,7 +227,7 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
-    "@types/bun": ["@types/bun@1.2.21", "", { "dependencies": { "bun-types": "1.2.21" } }, "sha512-NiDnvEqmbfQ6dmZ3EeUO577s4P5bf4HCTXtI6trMc6f6RzirY5IrF3aIookuSpyslFzrnvv2lmEWv5HyC1X79A=="],
+    "@types/bun": ["@types/bun@1.2.23", "", { "dependencies": { "bun-types": "1.2.23" } }, "sha512-le8ueOY5b6VKYf19xT3McVbXqLqmxzPXHsQT/q9JHgikJ2X22wyTW3g3ohz2ZMnp7dod6aduIiq8A14Xyimm0A=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -249,25 +251,25 @@
 
     "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.42.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.42.0", "@typescript-eslint/type-utils": "8.42.0", "@typescript-eslint/utils": "8.42.0", "@typescript-eslint/visitor-keys": "8.42.0", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.42.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Aq2dPqsQkxHOLfb2OPv43RnIvfj05nw8v/6n3B2NABIPpHnjQnaLo9QGMTvml+tv4korl/Cjfrb/BYhoL8UUTQ=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.45.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.45.0", "@typescript-eslint/type-utils": "8.45.0", "@typescript-eslint/utils": "8.45.0", "@typescript-eslint/visitor-keys": "8.45.0", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.45.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.42.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.42.0", "@typescript-eslint/types": "8.42.0", "@typescript-eslint/typescript-estree": "8.42.0", "@typescript-eslint/visitor-keys": "8.42.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.45.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.45.0", "@typescript-eslint/types": "8.45.0", "@typescript-eslint/typescript-estree": "8.45.0", "@typescript-eslint/visitor-keys": "8.45.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.42.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.42.0", "@typescript-eslint/types": "^8.42.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.45.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.45.0", "@typescript-eslint/types": "^8.45.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.42.0", "", { "dependencies": { "@typescript-eslint/types": "8.42.0", "@typescript-eslint/visitor-keys": "8.42.0" } }, "sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.45.0", "", { "dependencies": { "@typescript-eslint/types": "8.45.0", "@typescript-eslint/visitor-keys": "8.45.0" } }, "sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.42.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.45.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.42.0", "", { "dependencies": { "@typescript-eslint/types": "8.42.0", "@typescript-eslint/typescript-estree": "8.42.0", "@typescript-eslint/utils": "8.42.0", "debug": "^4.3.4", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-9KChw92sbPTYVFw3JLRH1ockhyR3zqqn9lQXol3/YbI6jVxzWoGcT3AsAW0mu1MY0gYtsXnUGV/AKpkAj5tVlQ=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.45.0", "", { "dependencies": { "@typescript-eslint/types": "8.45.0", "@typescript-eslint/typescript-estree": "8.45.0", "@typescript-eslint/utils": "8.45.0", "debug": "^4.3.4", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.42.0", "", {}, "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.45.0", "", {}, "sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.42.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.42.0", "@typescript-eslint/tsconfig-utils": "8.42.0", "@typescript-eslint/types": "8.42.0", "@typescript-eslint/visitor-keys": "8.42.0", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.45.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.45.0", "@typescript-eslint/tsconfig-utils": "8.45.0", "@typescript-eslint/types": "8.45.0", "@typescript-eslint/visitor-keys": "8.45.0", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.42.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.42.0", "@typescript-eslint/types": "8.42.0", "@typescript-eslint/typescript-estree": "8.42.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.45.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.45.0", "@typescript-eslint/types": "8.45.0", "@typescript-eslint/typescript-estree": "8.45.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.42.0", "", { "dependencies": { "@typescript-eslint/types": "8.42.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.45.0", "", { "dependencies": { "@typescript-eslint/types": "8.45.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
@@ -313,6 +315,10 @@
 
     "algoliasearch": ["algoliasearch@5.37.0", "", { "dependencies": { "@algolia/abtesting": "1.3.0", "@algolia/client-abtesting": "5.37.0", "@algolia/client-analytics": "5.37.0", "@algolia/client-common": "5.37.0", "@algolia/client-insights": "5.37.0", "@algolia/client-personalization": "5.37.0", "@algolia/client-query-suggestions": "5.37.0", "@algolia/client-search": "5.37.0", "@algolia/ingestion": "1.37.0", "@algolia/monitoring": "1.37.0", "@algolia/recommend": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-y7gau/ZOQDqoInTQp0IwTOjkrHc4Aq4R8JgpmCleFwiLl+PbN2DMWoDUWZnrK8AhNJwT++dn28Bt4NZYNLAmuA=="],
 
+    "ansi-escapes": ["ansi-escapes@7.1.1", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
@@ -325,7 +331,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.2.21", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-sa2Tj77Ijc/NTLS0/Odjq/qngmEPZfbfnOERi0KRUYhT9R8M4VBioWVmMWE5GrYbKMc+5lVybXygLdibHaqVqw=="],
+    "bun-types": ["bun-types@1.2.23", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-R9f0hKAZXgFU3mlrA0YpE/fiDvwV0FT9rORApt2aQVWSuJDzZOyB5QLc0N/4HF57CS8IXJ6+L5E4W1bW6NS2Aw=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -337,11 +343,19 @@
 
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-truncate": ["cli-truncate@5.1.0", "", { "dependencies": { "slice-ansi": "^7.1.0", "string-width": "^8.0.0" } }, "sha512-7JDGG+4Zp0CsknDCedl0DYdaeOhc46QNpXi3NLQblkZpXXgA6LncLDUUyvrjSvZeF3VRQa+KiMGomazQrC1V8g=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@14.0.1", "", {}, "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -359,15 +373,19 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "emoji-regex": ["emoji-regex@10.5.0", "", {}, "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg=="],
+
     "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
     "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.34.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.2.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.0", "@eslint/config-helpers": "^0.3.1", "@eslint/core": "^0.15.2", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.34.0", "@eslint/plugin-kit": "^0.3.5", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg=="],
+    "eslint": ["eslint@9.36.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.0", "@eslint/config-helpers": "^0.3.1", "@eslint/core": "^0.15.2", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.36.0", "@eslint/plugin-kit": "^0.3.5", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ=="],
 
     "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
 
@@ -386,6 +404,8 @@
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -411,9 +431,11 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
-    "globals": ["globals@16.3.0", "", {}, "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ=="],
+    "globals": ["globals@16.4.0", "", {}, "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw=="],
 
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
@@ -423,11 +445,13 @@
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
-    "hono": ["hono@4.9.6", "", {}, "sha512-doVjXhSFvYZ7y0dNokjwwSahcrAfdz+/BCLvAMa/vHLzjj8+CFyV5xteThGUsKdkaasgN+gF2mUxao+SGLpUeA=="],
+    "hono": ["hono@4.9.9", "", {}, "sha512-Hxw4wT6zjJGZJdkJzAx9PyBdf7ZpxaTSA0NfxqjLghwMrLBX8p33hJBzoETRakF3UJu6OdNQBZAlNSkGqKFukw=="],
 
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -437,6 +461,8 @@
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
@@ -445,7 +471,7 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "jiti": ["jiti@2.5.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w=="],
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
@@ -459,9 +485,15 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
+    "lint-staged": ["lint-staged@16.2.3", "", { "dependencies": { "commander": "^14.0.1", "listr2": "^9.0.4", "micromatch": "^4.0.8", "nano-spawn": "^1.0.3", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-1OnJEESB9zZqsp61XHH2fvpS1es3hRCxMplF/AJUDa8Ho8VrscYDIuxGrj3m8KPXbcWZ8fT9XTMUhEQmOVKpKw=="],
+
+    "listr2": ["listr2@9.0.4", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-1wd/kpAdKRLwv7/3OKC8zZ5U8e/fajCfWMxacUvB79S5nLrYGPtUI/8chMQhn3LQjsRVErTb9i1ECAwW0ZIHnQ=="],
+
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
     "magic-string": ["magic-string@0.30.18", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ=="],
 
@@ -483,6 +515,8 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minisearch": ["minisearch@7.1.2", "", {}, "sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA=="],
@@ -491,9 +525,13 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nano-spawn": ["nano-spawn@1.0.3", "", {}, "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
 
@@ -514,6 +552,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "pidtree": ["pidtree@0.6.0", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -537,6 +577,8 @@
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
@@ -555,13 +597,23 @@
 
     "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
 
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "speakingurl": ["speakingurl@14.0.1", "", {}, "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="],
 
+    "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
+
+    "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
+
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
@@ -579,9 +631,9 @@
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
-    "typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "typescript-eslint": ["typescript-eslint@8.42.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.42.0", "@typescript-eslint/parser": "8.42.0", "@typescript-eslint/typescript-estree": "8.42.0", "@typescript-eslint/utils": "8.42.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-ozR/rQn+aQXQxh1YgbCzQWDFrsi9mcg+1PM3l/z5o1+20P7suOIaNg515bpr/OYt6FObz/NHcBstydDLHWeEKg=="],
+    "typescript-eslint": ["typescript-eslint@8.45.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.45.0", "@typescript-eslint/parser": "8.45.0", "@typescript-eslint/typescript-estree": "8.45.0", "@typescript-eslint/utils": "8.45.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qzDmZw/Z5beNLUrXfd0HIW6MzIaAV5WNDxmMs9/3ojGOpYavofgNAAD/nC6tGV2PczIi0iw8vot2eAe/sBn7zg=="],
 
     "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
 
@@ -597,7 +649,7 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
     "valibot": ["valibot@1.1.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw=="],
 
@@ -615,9 +667,13 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "yaml": ["yaml@2.8.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw=="],
+
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.1.5", "", {}, "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg=="],
+    "zod": ["zod@4.1.11", "", {}, "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -630,6 +686,12 @@
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bun-ws-router",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A simple and efficient WebSocket router for Bun with Zod/Valibot message validation.",
   "keywords": [
     "broadcast",
@@ -67,7 +67,7 @@
     "index.ts"
   ],
   "dependencies": {
-    "uuid": "^11.1.0"
+    "uuid": "^13.0.0"
   },
   "peerDependencies": {
     "@types/bun": ">=1.1.0",
@@ -83,21 +83,24 @@
     }
   },
   "devDependencies": {
-    "@eslint/js": "^9.34.0",
-    "@types/bun": "^1.2.21",
-    "eslint": "^9.34.0",
+    "@eslint/js": "^9.36.0",
+    "@types/bun": "^1.2.23",
     "eslint-config-prettier": "^10.1.8",
-    "globals": "^16.3.0",
-    "hono": "^4.9.6",
-    "jiti": "^2.5.1",
+    "eslint": "^9.36.0",
+    "globals": "^16.4.0",
+    "hono": "^4.9.9",
+    "husky": "^9.1.7",
+    "jiti": "^2.6.1",
+    "lint-staged": "^16.2.3",
     "prettier": "^3.6.2",
-    "typescript": "^5.9.2",
-    "typescript-eslint": "^8.42.0",
+    "typescript-eslint": "^8.45.0",
+    "typescript": "^5.9.3",
     "valibot": "^1.1.0",
     "vitepress": "^1.6.4",
-    "zod": "^4.1.5"
+    "zod": "^4.1.11"
   },
   "scripts": {
+    "prepare": "husky",
     "build": "rm -rf dist && tsc --project tsconfig.build.json",
     "lint": "eslint --report-unused-disable-directives .",
     "lint:fix": "eslint --report-unused-disable-directives --fix .",
@@ -108,6 +111,14 @@
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "docs:deploy": "bunx gh-pages -d docs/.vitepress/dist"
+  },
+  "lint-staged": {
+    "*.{ts,js,json,md}": [
+      "bun prettier --write"
+    ],
+    "{shared,valibot,zod}/**/*.ts": [
+      "bun tsc --noEmit --skipLibCheck"
+    ]
   },
   "prettier": {
     "singleQuote": false,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -7,22 +7,32 @@ export interface WebSocketRouterOptions {
   server?: Server;
 }
 
-// WebSocket connection data that always includes clientId (UUID v7).
-// INVARIANT: clientId is generated on connection and never changes.
+/**
+ * WebSocket connection data that always includes clientId (UUID v7).
+ * INVARIANT: clientId is generated on connection and never changes.
+ */
 export type WebSocketData<T> = {
+  /** Unique client identifier (UUID v7) generated on connection */
   clientId: string;
 } & T;
 
-// Options for upgrading HTTP request to WebSocket connection.
-// NOTE: data is merged with auto-generated clientId to form WebSocketData<T>.
+/**
+ * Options for upgrading HTTP request to WebSocket connection.
+ * NOTE: data is merged with auto-generated clientId to form WebSocketData<T>.
+ */
 export interface UpgradeOptions<T> {
+  /** Bun server instance for WebSocket upgrade */
   server: Server;
+  /** Custom connection data, merged with clientId */
   data?: T;
+  /** HTTP headers to send in upgrade response */
   headers?: HeadersInit;
 }
 
 export interface OpenHandlerContext<Data> {
+  /** WebSocket connection with custom data */
   ws: ServerWebSocket<Data>;
+  /** Type-safe send function for validated messages */
   send: SendFunction;
 }
 
@@ -31,9 +41,13 @@ export type OpenHandler<Data = unknown> = (
 ) => void | Promise<void>;
 
 export interface CloseHandlerContext<Data> {
+  /** WebSocket connection with custom data */
   ws: ServerWebSocket<Data>;
+  /** WebSocket close code */
   code: number;
+  /** Optional close reason string */
   reason?: string;
+  /** Type-safe send function for validated messages */
   send: SendFunction;
 }
 
@@ -41,30 +55,40 @@ export type CloseHandler<Data = unknown> = (
   context: CloseHandlerContext<Data>,
 ) => void | Promise<void>;
 
-// [GENERIC VALIDATOR TYPES]
-// These use any to allow Zod and Valibot adapters to specialize them.
-// Each adapter provides its own strongly-typed version.
+/**
+ * Generic validator-agnostic types that are specialized by Zod and Valibot adapters.
+ * Each adapter provides strongly-typed versions in their respective modules.
+ */
+
+/** Generic send function, specialized by validator adapters */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type SendFunction = (schema: any, data: any, meta?: any) => void;
 
-// Base message context before validator-specific typing.
-// NOTE: Record<string, any> allows payload to be added via intersection.
+/**
+ * Base message context before validator-specific typing.
+ * Record<string, any> allows payload to be added via intersection.
+ */
 export type MessageContext<Data> = {
+  /** WebSocket connection with custom data */
   ws: ServerWebSocket<Data>;
+  /** Message metadata, typed by validator adapter */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   meta: any;
+  /** Type-safe send function for validated messages */
   send: SendFunction;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } & Record<string, any>;
 
-// Generic message handler signature.
-// NOTE: _Schema parameter exists for type consistency but isn't used in base type.
+/**
+ * Generic message handler signature.
+ * NOTE: _Schema parameter exists for type consistency but isn't used in base type.
+ */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export type MessageHandler<_Schema, Data> = (
   context: MessageContext<Data>,
 ) => void | Promise<void>;
 
-// Placeholder for validator-specific schema types
+/** Placeholder for validator-specific schema types */
 export type MessageSchemaType = any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 export interface MessageHandlerEntry<Data = unknown> {

--- a/specs/adrs.md
+++ b/specs/adrs.md
@@ -1,0 +1,43 @@
+# Architectural Decision Records
+
+## ADR-001: MessageContext Conditional Payload Typing
+
+**Status**: Implemented
+**Date**: 2025-10-01
+
+### Problem
+
+`MessageContext<Schema, Data>` incorrectly included `payload` property for ALL schemas, even those without payload. TypeScript failed to catch `ctx.payload` access in handlers for payload-less messages.
+
+### Decision
+
+Use explicit `keyof` check instead of structural `extends`:
+
+```typescript
+export type MessageContext<Schema extends MessageSchemaType, Data> = {
+  ws: ServerWebSocket<Data>;
+  type: Schema["shape"]["type"]["value"];
+  meta: z.infer<Schema["shape"]["meta"]>;
+  send: SendFunction;
+} & ("payload" extends keyof Schema["shape"]
+  ? Schema["shape"]["payload"] extends ZodType
+    ? { payload: z.infer<Schema["shape"]["payload"]> }
+    : Record<string, never>
+  : Record<string, never>);
+```
+
+### Rationale
+
+- Checks key existence, not structural compatibility
+- Avoids TypeScript's structural typing matching optional properties
+- More explicit and maintainable
+- Applied to both Zod and Valibot adapters
+
+### Constraints for AI Code Generation
+
+When generating message handler code:
+
+1. **NEVER** access `ctx.payload` unless schema explicitly defines payload
+2. **ALWAYS** use `ctx.type` for message type (added alongside this fix)
+3. Rely on TypeScript errors for payload access validation
+4. Add type-level tests using `expectTypeOf` for new message schemas

--- a/specs/router.md
+++ b/specs/router.md
@@ -1,0 +1,209 @@
+# WebSocket Router Specification
+
+## Overview
+
+Type-safe message routing for Bun WebSocket servers with automatic validation.
+
+## Basic Setup
+
+```typescript
+import { z } from "zod";
+import { WebSocketRouter, createMessageSchema } from "bun-ws-router/zod";
+
+const { messageSchema } = createMessageSchema(z);
+const router = new WebSocketRouter();
+
+const PingMessage = messageSchema("PING", { timestamp: z.number() });
+
+router.onMessage(PingMessage, (ctx) => {
+  console.log("Ping at:", ctx.payload.timestamp);
+  ctx.send(PongMessage, { reply: Date.now() });
+});
+
+Bun.serve({
+  fetch(req, server) {
+    return router.upgrade(req, { server });
+  },
+  websocket: router.websocket,
+});
+```
+
+## Router API
+
+### Message Handlers
+
+```typescript
+router.onMessage<Schema extends MessageSchemaType>(
+  schema: Schema,
+  handler: MessageHandler<Schema, Data>
+): WebSocketRouter<Data>
+```
+
+**Handler Context**:
+
+```typescript
+type MessageContext<Schema, Data> = {
+  ws: ServerWebSocket<Data>;
+  type: Schema["shape"]["type"]["value"]; // Message type literal
+  meta: z.infer<Schema["shape"]["meta"]>; // Metadata
+  payload: z.infer<Schema["shape"]["payload"]>; // Only if schema defines it
+  send: SendFunction; // Type-safe send function
+};
+```
+
+**Type Safety**: `ctx.payload` exists only when schema defines it:
+
+```typescript
+const WithPayload = messageSchema("WITH", { id: z.number() });
+const WithoutPayload = messageSchema("WITHOUT");
+
+router.onMessage(WithPayload, (ctx) => {
+  const id = ctx.payload.id; // ✅ Typed as number
+});
+
+router.onMessage(WithoutPayload, (ctx) => {
+  const p = ctx.payload; // ❌ Type error
+});
+```
+
+### Connection Lifecycle
+
+```typescript
+router.onOpen((ctx) => {
+  // ctx: { ws, send }
+});
+
+router.onClose((ctx) => {
+  // ctx: { ws, code, reason?, send }
+});
+```
+
+### WebSocket Upgrade
+
+```typescript
+router.upgrade(req, {
+  server,
+  data: { userId: "123" },  // Custom connection data
+  headers: { ... }
+});
+
+// Connection data type
+type WebSocketData<T> = {
+  clientId: string;  // Auto-generated UUID v7
+} & T;
+```
+
+### Route Composition
+
+```typescript
+const authRouter = new WebSocketRouter();
+authRouter.onMessage(LoginMessage, handleLogin);
+
+const chatRouter = new WebSocketRouter();
+chatRouter.onMessage(SendMessage, handleChat);
+
+const mainRouter = new WebSocketRouter()
+  .addRoutes(authRouter)
+  .addRoutes(chatRouter);
+```
+
+## Message Routing
+
+### Type-Based Routing
+
+Messages route by `type` field. Last registered handler wins:
+
+```typescript
+router.onMessage(TestMessage, handler1);
+router.onMessage(TestMessage, handler2); // ⚠️ Overwrites handler1
+// Console: Handler for "TEST" is being overwritten
+```
+
+### Validation Flow
+
+```
+Client Message → JSON Parse → Type Check → Handler Lookup → Validation → Handler
+```
+
+- Parse error → Logged, ignored
+- Missing type → Logged, ignored
+- No handler → Logged, ignored
+- Validation error → Logged, handler not called
+- Handler error → Logged, connection stays open
+
+## Type-Safe Sending
+
+```typescript
+const ResponseMsg = messageSchema("RESPONSE", { result: z.string() });
+
+router.onMessage(SomeMessage, (ctx) => {
+  ctx.send(ResponseMsg, { result: "ok" }); // ✅
+  ctx.send(ResponseMsg, { result: 123 }); // ❌ Type error
+});
+```
+
+## Broadcasting
+
+```typescript
+import { publish } from "bun-ws-router/zod/publish";
+
+router.onMessage(ChatMessage, (ctx) => {
+  const roomTopic = `room:${ctx.meta.roomId}`;
+  publish(ctx.ws, roomTopic, ChatMessage, {
+    text: ctx.payload.text,
+    sender: ctx.ws.data.userId,
+  });
+});
+```
+
+## Custom Connection Data
+
+```typescript
+type UserData = WebSocketData<{
+  userId: string;
+  roles: string[];
+}>;
+
+const router = new WebSocketRouter<UserData>();
+
+router.onMessage(SecureMessage, (ctx) => {
+  const userId = ctx.ws.data.userId; // ✅ Typed
+  const clientId = ctx.ws.data.clientId; // ✅ Always present
+});
+
+router.upgrade(req, {
+  server,
+  data: {
+    userId: "user-123",
+    roles: ["admin"],
+  },
+});
+```
+
+## Error Handling
+
+All errors are logged. Connections stay open unless handler explicitly closes.
+
+```typescript
+router.onMessage(ErrorMessage, async (ctx) => {
+  try {
+    await riskyOperation();
+  } catch (error) {
+    ctx.send(ErrorMessage, {
+      code: "INTERNAL_SERVER_ERROR",
+      message: error.message,
+    });
+  }
+});
+```
+
+## AI Code Generation Constraints
+
+1. **NEVER** access `ctx.payload` without checking schema defines payload
+2. **ALWAYS** wrap async operations in try/catch
+3. **ALWAYS** use `ctx.send()` for type-safe message sending
+4. Use `addRoutes()` for composition from feature modules
+5. Pass authentication/session data during `upgrade()`
+6. Use `publish()` for validated broadcasting
+7. Trust schema validation—don't re-validate in handlers
+8. Always handle promise rejections in async handlers

--- a/specs/schema.md
+++ b/specs/schema.md
@@ -1,0 +1,150 @@
+# Message Schema Specification
+
+## Factory Pattern (Critical)
+
+**MUST use factory pattern** to avoid dual package hazard with discriminated unions:
+
+```typescript
+import { z } from "zod";
+import { createMessageSchema } from "bun-ws-router/zod";
+
+const { messageSchema, createMessage } = createMessageSchema(z);
+```
+
+## Message Structure
+
+```typescript
+{
+  type: string,        // Message type literal (required)
+  meta: {              // Metadata (required, can be empty)
+    clientId?: string,
+    timestamp?: number,
+    correlationId?: string,
+  },
+  payload?: T          // Optional typed payload
+}
+```
+
+## Schema Patterns
+
+### Without Payload
+
+```typescript
+const PingMessage = messageSchema("PING");
+// { type: "PING", meta: { ... } }
+```
+
+### With Payload
+
+```typescript
+const JoinRoom = messageSchema("JOIN_ROOM", {
+  roomId: z.string(),
+});
+// { type: "JOIN_ROOM", meta: { ... }, payload: { roomId: string } }
+```
+
+### Extended Meta
+
+```typescript
+const RoomMessage = messageSchema(
+  "ROOM_MSG",
+  { text: z.string() },
+  { roomId: z.string() }, // Extended meta
+);
+// meta: { clientId?, timestamp?, correlationId?, roomId: string }
+```
+
+## Type Inference
+
+```typescript
+// Schema type
+type JoinRoomType = z.infer<typeof JoinRoom>;
+
+// Handler context type
+import type { MessageContext } from "bun-ws-router/zod";
+type Ctx = MessageContext<typeof JoinRoom, WebSocketData<{}>>;
+// {
+//   ws: ServerWebSocket<...>,
+//   type: "JOIN_ROOM",
+//   meta: { ... },
+//   payload: { roomId: string },  // ✅ Only if schema defines it
+//   send: SendFunction
+// }
+```
+
+## Conditional Payload Typing
+
+**Key Feature**: `ctx.payload` exists **only** when schema defines it:
+
+```typescript
+const WithPayload = messageSchema("WITH", { id: z.number() });
+const WithoutPayload = messageSchema("WITHOUT");
+
+router.onMessage(WithPayload, (ctx) => {
+  ctx.payload.id; // ✅ Typed as number
+});
+
+router.onMessage(WithoutPayload, (ctx) => {
+  ctx.payload; // ❌ Type error
+});
+```
+
+## Discriminated Unions
+
+```typescript
+const PingMsg = messageSchema("PING");
+const PongMsg = messageSchema("PONG", { reply: z.string() });
+
+const MessageUnion = z.discriminatedUnion("type", [PingMsg, PongMsg]);
+```
+
+**Critical**: Factory pattern required for discriminated unions to pass instanceof checks.
+
+## Client-Side Message Creation
+
+```typescript
+const { createMessage } = createMessageSchema(z);
+
+const msg = createMessage(JoinRoom, { roomId: "general" });
+if (msg.success) {
+  ws.send(JSON.stringify(msg.data));
+}
+```
+
+## Standard Error Schema
+
+```typescript
+const { ErrorMessage } = createMessageSchema(z);
+// {
+//   type: "ERROR",
+//   meta: { ... },
+//   payload: {
+//     code: ErrorCode,
+//     message?: string,
+//     context?: Record<string, any>
+//   }
+// }
+```
+
+### Error Codes
+
+```typescript
+type ErrorCode =
+  | "INVALID_MESSAGE_FORMAT"
+  | "VALIDATION_FAILED"
+  | "UNSUPPORTED_MESSAGE_TYPE"
+  | "AUTHENTICATION_FAILED"
+  | "AUTHORIZATION_FAILED"
+  | "RESOURCE_NOT_FOUND"
+  | "RATE_LIMIT_EXCEEDED"
+  | "INTERNAL_SERVER_ERROR";
+```
+
+## AI Code Generation Constraints
+
+1. **ALWAYS** use factory pattern: `createMessageSchema(validator)`
+2. **NEVER** import deprecated `messageSchema` directly
+3. **ALWAYS** check schema definition before accessing `ctx.payload`
+4. Use string literals for message types (enables routing and unions)
+5. Define payload as object schemas for proper type inference
+6. Add type-level tests with `expectTypeOf` for new schemas

--- a/test/message-context-types.test.ts
+++ b/test/message-context-types.test.ts
@@ -1,0 +1,141 @@
+/* SPDX-FileCopyrightText: 2025-present Kriasoft */
+/* SPDX-License-Identifier: MIT */
+
+import { describe, test, expectTypeOf } from "bun:test";
+import { z } from "zod";
+import { createMessageSchema } from "../zod/schema";
+import type { MessageContext, WebSocketData } from "../zod/types";
+
+describe("MessageContext type tests (Zod)", () => {
+  const { messageSchema } = createMessageSchema(z);
+
+  type DataType = WebSocketData<{ userId: string }>;
+
+  test("should include payload for schemas with payload", () => {
+    const WithPayload = messageSchema("WITH_PAYLOAD", {
+      value: z.string(),
+      count: z.number().optional(),
+    });
+    void WithPayload;
+
+    type Ctx = MessageContext<typeof WithPayload, DataType>;
+
+    // Should have payload property
+    expectTypeOf<Ctx>().toHaveProperty("payload");
+    expectTypeOf<Ctx["payload"]>().toHaveProperty("value");
+    expectTypeOf<Ctx["payload"]["value"]>().toBeString();
+    expectTypeOf<Ctx["payload"]["count"]>().toEqualTypeOf<number | undefined>();
+  });
+
+  test("should include type property from schema", () => {
+    const TestMessage = messageSchema("TEST_TYPE", {
+      data: z.string(),
+    });
+    void TestMessage;
+
+    type Ctx = MessageContext<typeof TestMessage, DataType>;
+
+    expectTypeOf<Ctx>().toHaveProperty("type");
+    expectTypeOf<Ctx["type"]>().toEqualTypeOf<"TEST_TYPE">();
+  });
+
+  test("should include meta property with correct type", () => {
+    const TestMessage = messageSchema("TEST_META");
+    void TestMessage;
+
+    type Ctx = MessageContext<typeof TestMessage, DataType>;
+
+    expectTypeOf<Ctx>().toHaveProperty("meta");
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("clientId");
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("timestamp");
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("correlationId");
+  });
+
+  test("should include extended meta properties", () => {
+    const CustomMessage = messageSchema(
+      "CUSTOM",
+      { data: z.string() },
+      { roomId: z.string(), priority: z.number() },
+    );
+    void CustomMessage;
+
+    type Ctx = MessageContext<typeof CustomMessage, DataType>;
+
+    // Should have both base and extended meta properties
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("clientId");
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("roomId");
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("priority");
+    expectTypeOf<Ctx["meta"]["roomId"]>().toBeString();
+    expectTypeOf<Ctx["meta"]["priority"]>().toBeNumber();
+  });
+
+  test("should include ws property with correct data type", () => {
+    const TestMessage = messageSchema("TEST_WS");
+    void TestMessage;
+
+    type Ctx = MessageContext<typeof TestMessage, DataType>;
+
+    expectTypeOf<Ctx>().toHaveProperty("ws");
+    expectTypeOf<Ctx["ws"]["data"]>().toHaveProperty("clientId");
+    expectTypeOf<Ctx["ws"]["data"]>().toHaveProperty("userId");
+    expectTypeOf<Ctx["ws"]["data"]["userId"]>().toBeString();
+  });
+
+  test("should include send function", () => {
+    const TestMessage = messageSchema("TEST_SEND");
+    void TestMessage;
+
+    type Ctx = MessageContext<typeof TestMessage, DataType>;
+
+    expectTypeOf<Ctx>().toHaveProperty("send");
+    expectTypeOf<Ctx["send"]>().toBeFunction();
+  });
+
+  test("handler should enforce correct context type", () => {
+    const MessageWithPayload = messageSchema("WITH", {
+      id: z.number(),
+    });
+    const MessageWithoutPayload = messageSchema("WITHOUT");
+    void MessageWithPayload;
+    void MessageWithoutPayload;
+
+    // Handler with payload - should have payload
+    const handlerWith = (
+      ctx: MessageContext<typeof MessageWithPayload, DataType>,
+    ) => {
+      expectTypeOf(ctx.payload.id).toBeNumber();
+    };
+
+    // Handler without payload - should NOT have payload
+    const handlerWithout = (
+      ctx: MessageContext<typeof MessageWithoutPayload, DataType>,
+    ) => {
+      // @ts-expect-error - payload should not exist
+      expectTypeOf(ctx.payload).toBeAny();
+    };
+
+    expectTypeOf(handlerWith).toBeFunction();
+    expectTypeOf(handlerWithout).toBeFunction();
+  });
+
+  test("complex payload types should be preserved", () => {
+    const ComplexMessage = messageSchema("COMPLEX", {
+      nested: z.object({
+        array: z.array(z.string()),
+        optional: z.number().optional(),
+        union: z.union([z.string(), z.number()]),
+      }),
+    });
+    void ComplexMessage;
+
+    type Ctx = MessageContext<typeof ComplexMessage, DataType>;
+
+    expectTypeOf<Ctx["payload"]["nested"]["array"]>().toEqualTypeOf<string[]>();
+    expectTypeOf<Ctx["payload"]["nested"]["optional"]>().toEqualTypeOf<
+      number | undefined
+    >();
+    expectTypeOf<Ctx["payload"]["nested"]["union"]>().toEqualTypeOf<
+      string | number
+    >();
+  });
+});

--- a/test/message-context-valibot-types.test.ts
+++ b/test/message-context-valibot-types.test.ts
@@ -1,0 +1,140 @@
+/* SPDX-FileCopyrightText: 2025-present Kriasoft */
+/* SPDX-License-Identifier: MIT */
+
+import { describe, test, expectTypeOf } from "bun:test";
+import * as v from "valibot";
+import { createMessageSchema } from "../valibot/schema";
+import type { MessageContext, WebSocketData } from "../valibot/types";
+
+const { messageSchema } = createMessageSchema(v);
+
+type DataType = WebSocketData<{ userId: string }>;
+
+// Define schemas outside test blocks to avoid ESLint "only used as type" errors
+const WithPayload = messageSchema("WITH_PAYLOAD", {
+  value: v.string(),
+  count: v.optional(v.number()),
+});
+void WithPayload;
+
+const TestMessage = messageSchema("TEST_TYPE", {
+  data: v.string(),
+});
+void TestMessage;
+const TestMetaMessage = messageSchema("TEST_META");
+void TestMetaMessage;
+
+const CustomMessage = messageSchema(
+  "CUSTOM",
+  { data: v.string() },
+  { roomId: v.string(), priority: v.number() },
+);
+void CustomMessage;
+
+const TestWsMessage = messageSchema("TEST_WS");
+void TestWsMessage;
+const TestSendMessage = messageSchema("TEST_SEND");
+void TestSendMessage;
+
+const MessageWithPayload = messageSchema("WITH", {
+  id: v.number(),
+});
+void MessageWithPayload;
+const MessageWithoutPayload = messageSchema("WITHOUT");
+void MessageWithoutPayload;
+
+const ComplexMessage = messageSchema("COMPLEX", {
+  nested: v.object({
+    array: v.array(v.string()),
+    optional: v.optional(v.number()),
+    union: v.union([v.string(), v.number()]),
+  }),
+});
+void ComplexMessage;
+
+describe("MessageContext type tests (Valibot)", () => {
+  test("should include payload for schemas with payload", () => {
+    type Ctx = MessageContext<typeof WithPayload, DataType>;
+
+    // Should have payload property
+    expectTypeOf<Ctx>().toHaveProperty("payload");
+    expectTypeOf<Ctx["payload"]>().toHaveProperty("value");
+    expectTypeOf<Ctx["payload"]["value"]>().toBeString();
+    expectTypeOf<Ctx["payload"]["count"]>().toEqualTypeOf<number | undefined>();
+  });
+
+  test("should include type property from schema", () => {
+    type Ctx = MessageContext<typeof TestMessage, DataType>;
+
+    expectTypeOf<Ctx>().toHaveProperty("type");
+    expectTypeOf<Ctx["type"]>().toEqualTypeOf<"TEST_TYPE">();
+  });
+
+  test("should include meta property with correct type", () => {
+    type Ctx = MessageContext<typeof TestMetaMessage, DataType>;
+
+    expectTypeOf<Ctx>().toHaveProperty("meta");
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("clientId");
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("timestamp");
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("correlationId");
+  });
+
+  test("should include extended meta properties", () => {
+    type Ctx = MessageContext<typeof CustomMessage, DataType>;
+
+    // Should have both base and extended meta properties
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("clientId");
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("roomId");
+    expectTypeOf<Ctx["meta"]>().toHaveProperty("priority");
+    expectTypeOf<Ctx["meta"]["roomId"]>().toBeString();
+    expectTypeOf<Ctx["meta"]["priority"]>().toBeNumber();
+  });
+
+  test("should include ws property with correct data type", () => {
+    type Ctx = MessageContext<typeof TestWsMessage, DataType>;
+
+    expectTypeOf<Ctx>().toHaveProperty("ws");
+    expectTypeOf<Ctx["ws"]["data"]>().toHaveProperty("clientId");
+    expectTypeOf<Ctx["ws"]["data"]>().toHaveProperty("userId");
+    expectTypeOf<Ctx["ws"]["data"]["userId"]>().toBeString();
+  });
+
+  test("should include send function", () => {
+    type Ctx = MessageContext<typeof TestSendMessage, DataType>;
+
+    expectTypeOf<Ctx>().toHaveProperty("send");
+    expectTypeOf<Ctx["send"]>().toBeFunction();
+  });
+
+  test("handler should enforce correct context type", () => {
+    // Handler with payload - should have payload
+    const handlerWith = (
+      ctx: MessageContext<typeof MessageWithPayload, DataType>,
+    ) => {
+      expectTypeOf(ctx.payload.id).toBeNumber();
+    };
+
+    // Handler without payload - should NOT have payload
+    const handlerWithout = (
+      ctx: MessageContext<typeof MessageWithoutPayload, DataType>,
+    ) => {
+      // @ts-expect-error - payload should not exist
+      expectTypeOf(ctx.payload).toBeAny();
+    };
+
+    expectTypeOf(handlerWith).toBeFunction();
+    expectTypeOf(handlerWithout).toBeFunction();
+  });
+
+  test("complex payload types should be preserved", () => {
+    type Ctx = MessageContext<typeof ComplexMessage, DataType>;
+
+    expectTypeOf<Ctx["payload"]["nested"]["array"]>().toEqualTypeOf<string[]>();
+    expectTypeOf<Ctx["payload"]["nested"]["optional"]>().toEqualTypeOf<
+      number | undefined
+    >();
+    expectTypeOf<Ctx["payload"]["nested"]["union"]>().toEqualTypeOf<
+      string | number
+    >();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes type inference issue where `ctx.payload` was incorrectly available for message schemas without payload definitions. The fix uses explicit `keyof` checks instead of structural `extends` to properly handle discriminated unions and prevent false type matches.

**Changes:**
- Updated `MessageContext` type in both Zod and Valibot adapters to use `keyof` check for payload existence
- Added `type` property to `MessageContext` for accessing message type literal
- Enhanced TSDoc comments across shared types for better documentation
- Added comprehensive type-level tests for both adapters
- Created specs and ADRs documenting the fix and architecture decisions
- Version bump to 0.4.4

**Why this matters:**
TypeScript's structural typing can match optional properties against `extends` checks, causing the previous implementation to incorrectly add `payload` to contexts for payload-less schemas. The `keyof` approach explicitly checks for key existence, ensuring proper type safety.
