### PR TITLE
feat: add typed client adapters with full type inference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -42,3 +45,17 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run prettier --check .
       - run: bun run eslint .
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+      - run: bun install --frozen-lockfile
+      - run: bun run docs:build

--- a/bun.lock
+++ b/bun.lock
@@ -7,24 +7,24 @@
         "uuid": "^13.0.0",
       },
       "devDependencies": {
-        "@eslint/js": "^9.36.0",
+        "@eslint/js": "^9.37.0",
         "@types/bun": "^1.2.23",
-        "eslint": "^9.36.0",
+        "eslint": "^9.37.0",
         "eslint-config-prettier": "^10.1.8",
         "globals": "^16.4.0",
-        "hono": "^4.9.9",
+        "hono": "^4.9.10",
         "husky": "^9.1.7",
         "jiti": "^2.6.1",
         "lint-staged": "^16.2.3",
         "prettier": "^3.6.2",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.45.0",
+        "typescript-eslint": "^8.46.0",
         "valibot": "^1.1.0",
         "vitepress": "^1.6.4",
-        "zod": "^4.1.11",
+        "zod": "^4.1.12",
       },
       "peerDependencies": {
-        "@types/bun": ">1.2.23",
+        "@types/bun": ">=1.1.0",
         "valibot": ">=1.1.0",
         "zod": ">=4.0.14",
       },
@@ -35,7 +35,7 @@
     },
   },
   "packages": {
-    "@algolia/abtesting": ["@algolia/abtesting@1.3.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-KqPVLdVNfoJzX5BKNGM9bsW8saHeyax8kmPFXul5gejrSPN3qss7PgsFH5mMem7oR8tvjvNkia97ljEYPYCN8Q=="],
+    "@algolia/abtesting": ["@algolia/abtesting@1.5.0", "", { "dependencies": { "@algolia/client-common": "5.39.0", "@algolia/requester-browser-xhr": "5.39.0", "@algolia/requester-fetch": "5.39.0", "@algolia/requester-node-http": "5.39.0" } }, "sha512-W/ohRkbKQsqDWALJg28X15KF7Tcyg53L1MfdOkLgvkcCcofdzGHSimHHeNG05ojjFw9HK8+VPhe/Vwq4MozIJg=="],
 
     "@algolia/autocomplete-core": ["@algolia/autocomplete-core@1.17.7", "", { "dependencies": { "@algolia/autocomplete-plugin-algolia-insights": "1.17.7", "@algolia/autocomplete-shared": "1.17.7" } }, "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q=="],
 
@@ -45,39 +45,39 @@
 
     "@algolia/autocomplete-shared": ["@algolia/autocomplete-shared@1.17.7", "", { "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg=="],
 
-    "@algolia/client-abtesting": ["@algolia/client-abtesting@5.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-Dp2Zq+x9qQFnuiQhVe91EeaaPxWBhzwQ6QnznZQnH9C1/ei3dvtmAFfFeaTxM6FzfJXDLvVnaQagTYFTQz3R5g=="],
+    "@algolia/client-abtesting": ["@algolia/client-abtesting@5.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0", "@algolia/requester-browser-xhr": "5.39.0", "@algolia/requester-fetch": "5.39.0", "@algolia/requester-node-http": "5.39.0" } }, "sha512-Vf0ZVe+qo3sHDrCinouJqlg8VoxM4Qo/KxNIqMYybkuctutfnp3kIY9OmESplOQ/9NGBthU9EG+4d5fBibWK/A=="],
 
-    "@algolia/client-analytics": ["@algolia/client-analytics@5.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-wyXODDOluKogTuZxRII6mtqhAq4+qUR3zIUJEKTiHLe8HMZFxfUEI4NO2qSu04noXZHbv/sRVdQQqzKh12SZuQ=="],
+    "@algolia/client-analytics": ["@algolia/client-analytics@5.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0", "@algolia/requester-browser-xhr": "5.39.0", "@algolia/requester-fetch": "5.39.0", "@algolia/requester-node-http": "5.39.0" } }, "sha512-V16ITZxYIwcv1arNce65JZmn94Ft6vKlBZ//gXw8AvIH32glJz1KcbaVAUr9p7PYlGZ/XVHP6LxDgrpNdtwgcA=="],
 
-    "@algolia/client-common": ["@algolia/client-common@5.37.0", "", {}, "sha512-GylIFlPvLy9OMgFG8JkonIagv3zF+Dx3H401Uo2KpmfMVBBJiGfAb9oYfXtplpRMZnZPxF5FnkWaI/NpVJMC+g=="],
+    "@algolia/client-common": ["@algolia/client-common@5.39.0", "", {}, "sha512-UCJTuwySEQeiKPWV3wruhuI/wHbDYenHzgL9pYsvh6r/u5Z+g61ip1iwdAlFp02CnywzI9O7+AQPh2ManYyHmQ=="],
 
-    "@algolia/client-insights": ["@algolia/client-insights@5.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-T63afO2O69XHKw2+F7mfRoIbmXWGzgpZxgOFAdP3fR4laid7pWBt20P4eJ+Zn23wXS5kC9P2K7Bo3+rVjqnYiw=="],
+    "@algolia/client-insights": ["@algolia/client-insights@5.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0", "@algolia/requester-browser-xhr": "5.39.0", "@algolia/requester-fetch": "5.39.0", "@algolia/requester-node-http": "5.39.0" } }, "sha512-s0ia8M/ZZR+iO2uLNTBrlQdEb6ZMAMcKMHckp5mcoglxrf8gHifL4LmdhGKdAxAn3UIagtqIP0RCnIymHUbm7A=="],
 
-    "@algolia/client-personalization": ["@algolia/client-personalization@5.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-1zOIXM98O9zD8bYDCJiUJRC/qNUydGHK/zRK+WbLXrW1SqLFRXECsKZa5KoG166+o5q5upk96qguOtE8FTXDWQ=="],
+    "@algolia/client-personalization": ["@algolia/client-personalization@5.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0", "@algolia/requester-browser-xhr": "5.39.0", "@algolia/requester-fetch": "5.39.0", "@algolia/requester-node-http": "5.39.0" } }, "sha512-vZPIt7Lw+toNsHZUiPhNIc1Z3vUjDp7nzn6AMOaPC73gEuTq2iLPNvM06CSB6aHePo5eMeJIP5YEKBUQUA/PJA=="],
 
-    "@algolia/client-query-suggestions": ["@algolia/client-query-suggestions@5.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-31Nr2xOLBCYVal+OMZn1rp1H4lPs1914Tfr3a34wU/nsWJ+TB3vWjfkUUuuYhWoWBEArwuRzt3YNLn0F/KRVkg=="],
+    "@algolia/client-query-suggestions": ["@algolia/client-query-suggestions@5.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0", "@algolia/requester-browser-xhr": "5.39.0", "@algolia/requester-fetch": "5.39.0", "@algolia/requester-node-http": "5.39.0" } }, "sha512-jcPQr3iKTWNVli2NYHPv02aNLwixDjPCpOgMp9CZTvEiPI6Ec4jHX+oFr3LDZagOFY9e1xJhc/JrgMGGW1sHnw=="],
 
-    "@algolia/client-search": ["@algolia/client-search@5.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-DAFVUvEg+u7jUs6BZiVz9zdaUebYULPiQ4LM2R4n8Nujzyj7BZzGr2DCd85ip4p/cx7nAZWKM8pLcGtkTRTdsg=="],
+    "@algolia/client-search": ["@algolia/client-search@5.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0", "@algolia/requester-browser-xhr": "5.39.0", "@algolia/requester-fetch": "5.39.0", "@algolia/requester-node-http": "5.39.0" } }, "sha512-/IYpF10BpthGZEJQZMhMqV4AqWr5avcWfZm/SIKK1RvUDmzGqLoW/+xeJVX9C8ZnNkIC8hivbIQFaNaRw0BFZQ=="],
 
-    "@algolia/ingestion": ["@algolia/ingestion@1.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-pkCepBRRdcdd7dTLbFddnu886NyyxmhgqiRcHHaDunvX03Ij4WzvouWrQq7B7iYBjkMQrLS8wQqSP0REfA4W8g=="],
+    "@algolia/ingestion": ["@algolia/ingestion@1.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0", "@algolia/requester-browser-xhr": "5.39.0", "@algolia/requester-fetch": "5.39.0", "@algolia/requester-node-http": "5.39.0" } }, "sha512-IgSHKUiuecqLfBlXiuCSdRTdsO3/yvpmXrMFz8fAJ8M4QmDtHkOuD769dmybRYqsbYMHivw+lir4BgbRGMtOIQ=="],
 
-    "@algolia/monitoring": ["@algolia/monitoring@1.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-fNw7pVdyZAAQQCJf1cc/ih4fwrRdQSgKwgor4gchsI/Q/ss9inmC6bl/69jvoRSzgZS9BX4elwHKdo0EfTli3w=="],
+    "@algolia/monitoring": ["@algolia/monitoring@1.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0", "@algolia/requester-browser-xhr": "5.39.0", "@algolia/requester-fetch": "5.39.0", "@algolia/requester-node-http": "5.39.0" } }, "sha512-8Xnd4+609SKC/hqVsuFc4evFBmvA2765/4NcH+Dpr756SKPbL1BY0X8kVxlmM3YBLNqnduSQxHxpDJUK58imCA=="],
 
-    "@algolia/recommend": ["@algolia/recommend@5.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-U+FL5gzN2ldx3TYfQO5OAta2TBuIdabEdFwD5UVfWPsZE5nvOKkc/6BBqP54Z/adW/34c5ZrvvZhlhNTZujJXQ=="],
+    "@algolia/recommend": ["@algolia/recommend@5.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0", "@algolia/requester-browser-xhr": "5.39.0", "@algolia/requester-fetch": "5.39.0", "@algolia/requester-node-http": "5.39.0" } }, "sha512-D7Ye2Ss/5xqUkQUxKm/VqEJLt5kARd9IMmjdzlxaKhGgNlOemTay0lwBmOVFuJRp7UODjp5c9+K+B8g0ORObIw=="],
 
-    "@algolia/requester-browser-xhr": ["@algolia/requester-browser-xhr@5.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0" } }, "sha512-Ao8GZo8WgWFABrU7iq+JAftXV0t+UcOtCDL4mzHHZ+rQeTTf1TZssr4d0vIuoqkVNnKt9iyZ7T4lQff4ydcTrw=="],
+    "@algolia/requester-browser-xhr": ["@algolia/requester-browser-xhr@5.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0" } }, "sha512-mgPte1ZJqpk9dkVs44J3wKAbHATvHZNlSpzhMdjMLIg/3qTycSZyDiomLiSlxE8CLsxyBAOJWnyKRHfom+Z1rg=="],
 
-    "@algolia/requester-fetch": ["@algolia/requester-fetch@5.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0" } }, "sha512-H7OJOXrFg5dLcGJ22uxx8eiFId0aB9b0UBhoOi4SMSuDBe6vjJJ/LeZyY25zPaSvkXNBN3vAM+ad6M0h6ha3AA=="],
+    "@algolia/requester-fetch": ["@algolia/requester-fetch@5.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0" } }, "sha512-LIrCkrxu1WnO3ev1+w6NnZ12JZL/o+2H9w6oWnZAjQZIlA/Ym6M9QHkt+OQ/SwkuoiNkW3DAo+Pi4A2V9FPtqg=="],
 
-    "@algolia/requester-node-http": ["@algolia/requester-node-http@5.37.0", "", { "dependencies": { "@algolia/client-common": "5.37.0" } }, "sha512-npZ9aeag4SGTx677eqPL3rkSPlQrnzx/8wNrl1P7GpWq9w/eTmRbOq+wKrJ2r78idlY0MMgmY/mld2tq6dc44g=="],
+    "@algolia/requester-node-http": ["@algolia/requester-node-http@5.39.0", "", { "dependencies": { "@algolia/client-common": "5.39.0" } }, "sha512-6beG+egPwXmvhAg+m0STCj+ZssDcjrLzf4L05aKm2nGglMXSSPz0cH/rM+kVD9krNfldiMctURd4wjojW1fV0w=="],
 
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
 
-    "@babel/parser": ["@babel/parser@7.28.3", "", { "dependencies": { "@babel/types": "^7.28.2" }, "bin": "./bin/babel-parser.js" }, "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA=="],
+    "@babel/parser": ["@babel/parser@7.28.4", "", { "dependencies": { "@babel/types": "^7.28.4" }, "bin": "./bin/babel-parser.js" }, "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg=="],
 
-    "@babel/types": ["@babel/types@7.28.2", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ=="],
+    "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
     "@docsearch/css": ["@docsearch/css@3.8.2", "", {}, "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ=="],
 
@@ -131,23 +131,23 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
-    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.8.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q=="],
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
 
     "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.1", "", {}, "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ=="],
 
     "@eslint/config-array": ["@eslint/config-array@0.21.0", "", { "dependencies": { "@eslint/object-schema": "^2.1.6", "debug": "^4.3.1", "minimatch": "^3.1.2" } }, "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ=="],
 
-    "@eslint/config-helpers": ["@eslint/config-helpers@0.3.1", "", {}, "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA=="],
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.0", "", { "dependencies": { "@eslint/core": "^0.16.0" } }, "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog=="],
 
-    "@eslint/core": ["@eslint/core@0.15.2", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg=="],
+    "@eslint/core": ["@eslint/core@0.16.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q=="],
 
     "@eslint/eslintrc": ["@eslint/eslintrc@3.3.1", "", { "dependencies": { "ajv": "^6.12.4", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.0", "minimatch": "^3.1.2", "strip-json-comments": "^3.1.1" } }, "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ=="],
 
-    "@eslint/js": ["@eslint/js@9.36.0", "", {}, "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw=="],
+    "@eslint/js": ["@eslint/js@9.37.0", "", {}, "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg=="],
 
     "@eslint/object-schema": ["@eslint/object-schema@2.1.6", "", {}, "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA=="],
 
-    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.3.5", "", { "dependencies": { "@eslint/core": "^0.15.2", "levn": "^0.4.1" } }, "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w=="],
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.0", "", { "dependencies": { "@eslint/core": "^0.16.0", "levn": "^0.4.1" } }, "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -157,7 +157,7 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
-    "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.50", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-Z2ggRwKYEBB9eYAEi4NqEgIzyLhu0Buh4+KGzMPD6+xG7mk52wZJwLT/glDPtfslV503VtJbqzWqBUGkCMKOFA=="],
+    "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.54", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-OQQYl8yC5j3QklZOYnK31QYe5h47IhyCoxSLd53f0e0nA4dgi8VOZS30SgSAbsecQ+S0xlGJMjXIHTIqZ+ML3w=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
@@ -169,47 +169,49 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.50.0", "", { "os": "android", "cpu": "arm" }, "sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ=="],
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.52.4", "", { "os": "android", "cpu": "arm" }, "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA=="],
 
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.50.0", "", { "os": "android", "cpu": "arm64" }, "sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw=="],
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.52.4", "", { "os": "android", "cpu": "arm64" }, "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w=="],
 
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.50.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg=="],
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.52.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg=="],
 
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.50.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw=="],
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.52.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw=="],
 
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.50.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ=="],
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.52.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ=="],
 
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.50.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA=="],
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.52.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw=="],
 
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.50.0", "", { "os": "linux", "cpu": "arm" }, "sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w=="],
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.52.4", "", { "os": "linux", "cpu": "arm" }, "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ=="],
 
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.50.0", "", { "os": "linux", "cpu": "arm" }, "sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg=="],
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.52.4", "", { "os": "linux", "cpu": "arm" }, "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q=="],
 
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.50.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g=="],
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.52.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg=="],
 
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.50.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ=="],
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.52.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g=="],
 
-    "@rollup/rollup-linux-loongarch64-gnu": ["@rollup/rollup-linux-loongarch64-gnu@4.50.0", "", { "os": "linux", "cpu": "none" }, "sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ=="],
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.52.4", "", { "os": "linux", "cpu": "none" }, "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ=="],
 
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.50.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg=="],
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.52.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g=="],
 
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.50.0", "", { "os": "linux", "cpu": "none" }, "sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA=="],
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.52.4", "", { "os": "linux", "cpu": "none" }, "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg=="],
 
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.50.0", "", { "os": "linux", "cpu": "none" }, "sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ=="],
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.52.4", "", { "os": "linux", "cpu": "none" }, "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA=="],
 
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.50.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ=="],
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.52.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA=="],
 
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.50.0", "", { "os": "linux", "cpu": "x64" }, "sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA=="],
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.52.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg=="],
 
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.50.0", "", { "os": "linux", "cpu": "x64" }, "sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw=="],
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.52.4", "", { "os": "linux", "cpu": "x64" }, "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw=="],
 
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.50.0", "", { "os": "none", "cpu": "arm64" }, "sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q=="],
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.52.4", "", { "os": "none", "cpu": "arm64" }, "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA=="],
 
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.50.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg=="],
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.52.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ=="],
 
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.50.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw=="],
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.52.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw=="],
 
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.50.0", "", { "os": "win32", "cpu": "x64" }, "sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg=="],
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.52.4", "", { "os": "win32", "cpu": "x64" }, "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.52.4", "", { "os": "win32", "cpu": "x64" }, "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w=="],
 
     "@shikijs/core": ["@shikijs/core@2.5.0", "", { "dependencies": { "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.4" } }, "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg=="],
 
@@ -243,45 +245,45 @@
 
     "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
-    "@types/node": ["@types/node@24.3.1", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g=="],
+    "@types/node": ["@types/node@24.7.0", "", { "dependencies": { "undici-types": "~7.14.0" } }, "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw=="],
 
-    "@types/react": ["@types/react@19.1.12", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w=="],
+    "@types/react": ["@types/react@19.2.0", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.45.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.45.0", "@typescript-eslint/type-utils": "8.45.0", "@typescript-eslint/utils": "8.45.0", "@typescript-eslint/visitor-keys": "8.45.0", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.45.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.46.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.46.0", "@typescript-eslint/type-utils": "8.46.0", "@typescript-eslint/utils": "8.46.0", "@typescript-eslint/visitor-keys": "8.46.0", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.46.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-hA8gxBq4ukonVXPy0OKhiaUh/68D0E88GSmtC1iAEnGaieuDi38LhS7jdCHRLi6ErJBNDGCzvh5EnzdPwUc0DA=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.45.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.45.0", "@typescript-eslint/types": "8.45.0", "@typescript-eslint/typescript-estree": "8.45.0", "@typescript-eslint/visitor-keys": "8.45.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.46.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.46.0", "@typescript-eslint/types": "8.46.0", "@typescript-eslint/typescript-estree": "8.46.0", "@typescript-eslint/visitor-keys": "8.46.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.45.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.45.0", "@typescript-eslint/types": "^8.45.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.46.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.46.0", "@typescript-eslint/types": "^8.46.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-OEhec0mH+U5Je2NZOeK1AbVCdm0ChyapAyTeXVIYTPXDJ3F07+cu87PPXcGoYqZ7M9YJVvFnfpGg1UmCIqM+QQ=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.45.0", "", { "dependencies": { "@typescript-eslint/types": "8.45.0", "@typescript-eslint/visitor-keys": "8.45.0" } }, "sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.46.0", "", { "dependencies": { "@typescript-eslint/types": "8.46.0", "@typescript-eslint/visitor-keys": "8.46.0" } }, "sha512-lWETPa9XGcBes4jqAMYD9fW0j4n6hrPtTJwWDmtqgFO/4HF4jmdH/Q6wggTw5qIT5TXjKzbt7GsZUBnWoO3dqw=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.45.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.46.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-WrYXKGAHY836/N7zoK/kzi6p8tXFhasHh8ocFL9VZSAkvH956gfeRfcnhs3xzRy8qQ/dq3q44v1jvQieMFg2cw=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.45.0", "", { "dependencies": { "@typescript-eslint/types": "8.45.0", "@typescript-eslint/typescript-estree": "8.45.0", "@typescript-eslint/utils": "8.45.0", "debug": "^4.3.4", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.46.0", "", { "dependencies": { "@typescript-eslint/types": "8.46.0", "@typescript-eslint/typescript-estree": "8.46.0", "@typescript-eslint/utils": "8.46.0", "debug": "^4.3.4", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-hy+lvYV1lZpVs2jRaEYvgCblZxUoJiPyCemwbQZ+NGulWkQRy0HRPYAoef/CNSzaLt+MLvMptZsHXHlkEilaeg=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.45.0", "", {}, "sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.46.0", "", {}, "sha512-bHGGJyVjSE4dJJIO5yyEWt/cHyNwga/zXGJbJJ8TiO01aVREK6gCTu3L+5wrkb1FbDkQ+TKjMNe9R/QQQP9+rA=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.45.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.45.0", "@typescript-eslint/tsconfig-utils": "8.45.0", "@typescript-eslint/types": "8.45.0", "@typescript-eslint/visitor-keys": "8.45.0", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.46.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.46.0", "@typescript-eslint/tsconfig-utils": "8.46.0", "@typescript-eslint/types": "8.46.0", "@typescript-eslint/visitor-keys": "8.46.0", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-ekDCUfVpAKWJbRfm8T1YRrCot1KFxZn21oV76v5Fj4tr7ELyk84OS+ouvYdcDAwZL89WpEkEj2DKQ+qg//+ucg=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.45.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.45.0", "@typescript-eslint/types": "8.45.0", "@typescript-eslint/typescript-estree": "8.45.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.46.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.46.0", "@typescript-eslint/types": "8.46.0", "@typescript-eslint/typescript-estree": "8.46.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-nD6yGWPj1xiOm4Gk0k6hLSZz2XkNXhuYmyIrOWcHoPuAhjT9i5bAG+xbWPgFeNR8HPHHtpNKdYUXJl/D3x7f5g=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.45.0", "", { "dependencies": { "@typescript-eslint/types": "8.45.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.46.0", "", { "dependencies": { "@typescript-eslint/types": "8.46.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-FrvMpAK+hTbFy7vH5j1+tMYHMSKLE6RzluFJlkFNKD0p9YsUT75JlBSmr5so3QRzvMwU5/bIEdeNrxm8du8l3Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
 
-    "@vue/compiler-core": ["@vue/compiler-core@3.5.21", "", { "dependencies": { "@babel/parser": "^7.28.3", "@vue/shared": "3.5.21", "entities": "^4.5.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw=="],
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.22", "", { "dependencies": { "@babel/parser": "^7.28.4", "@vue/shared": "3.5.22", "entities": "^4.5.0", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ=="],
 
-    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.21", "", { "dependencies": { "@vue/compiler-core": "3.5.21", "@vue/shared": "3.5.21" } }, "sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ=="],
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.22", "", { "dependencies": { "@vue/compiler-core": "3.5.22", "@vue/shared": "3.5.22" } }, "sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA=="],
 
-    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.21", "", { "dependencies": { "@babel/parser": "^7.28.3", "@vue/compiler-core": "3.5.21", "@vue/compiler-dom": "3.5.21", "@vue/compiler-ssr": "3.5.21", "@vue/shared": "3.5.21", "estree-walker": "^2.0.2", "magic-string": "^0.30.18", "postcss": "^8.5.6", "source-map-js": "^1.2.1" } }, "sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ=="],
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.22", "", { "dependencies": { "@babel/parser": "^7.28.4", "@vue/compiler-core": "3.5.22", "@vue/compiler-dom": "3.5.22", "@vue/compiler-ssr": "3.5.22", "@vue/shared": "3.5.22", "estree-walker": "^2.0.2", "magic-string": "^0.30.19", "postcss": "^8.5.6", "source-map-js": "^1.2.1" } }, "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ=="],
 
-    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.21", "", { "dependencies": { "@vue/compiler-dom": "3.5.21", "@vue/shared": "3.5.21" } }, "sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w=="],
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.22", "", { "dependencies": { "@vue/compiler-dom": "3.5.22", "@vue/shared": "3.5.22" } }, "sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww=="],
 
     "@vue/devtools-api": ["@vue/devtools-api@7.7.7", "", { "dependencies": { "@vue/devtools-kit": "^7.7.7" } }, "sha512-lwOnNBH2e7x1fIIbVT7yF5D+YWhqELm55/4ZKf45R9T8r9dE2AIOy8HKjfqzGsoTHFbWbr337O4E0A0QADnjBg=="],
 
@@ -289,15 +291,15 @@
 
     "@vue/devtools-shared": ["@vue/devtools-shared@7.7.7", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw=="],
 
-    "@vue/reactivity": ["@vue/reactivity@3.5.21", "", { "dependencies": { "@vue/shared": "3.5.21" } }, "sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA=="],
+    "@vue/reactivity": ["@vue/reactivity@3.5.22", "", { "dependencies": { "@vue/shared": "3.5.22" } }, "sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A=="],
 
-    "@vue/runtime-core": ["@vue/runtime-core@3.5.21", "", { "dependencies": { "@vue/reactivity": "3.5.21", "@vue/shared": "3.5.21" } }, "sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA=="],
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.22", "", { "dependencies": { "@vue/reactivity": "3.5.22", "@vue/shared": "3.5.22" } }, "sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ=="],
 
-    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.21", "", { "dependencies": { "@vue/reactivity": "3.5.21", "@vue/runtime-core": "3.5.21", "@vue/shared": "3.5.21", "csstype": "^3.1.3" } }, "sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w=="],
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.22", "", { "dependencies": { "@vue/reactivity": "3.5.22", "@vue/runtime-core": "3.5.22", "@vue/shared": "3.5.22", "csstype": "^3.1.3" } }, "sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww=="],
 
-    "@vue/server-renderer": ["@vue/server-renderer@3.5.21", "", { "dependencies": { "@vue/compiler-ssr": "3.5.21", "@vue/shared": "3.5.21" }, "peerDependencies": { "vue": "3.5.21" } }, "sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA=="],
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.22", "", { "dependencies": { "@vue/compiler-ssr": "3.5.22", "@vue/shared": "3.5.22" }, "peerDependencies": { "vue": "3.5.22" } }, "sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ=="],
 
-    "@vue/shared": ["@vue/shared@3.5.21", "", {}, "sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw=="],
+    "@vue/shared": ["@vue/shared@3.5.22", "", {}, "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w=="],
 
     "@vueuse/core": ["@vueuse/core@12.8.2", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" } }, "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ=="],
 
@@ -313,7 +315,7 @@
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
-    "algoliasearch": ["algoliasearch@5.37.0", "", { "dependencies": { "@algolia/abtesting": "1.3.0", "@algolia/client-abtesting": "5.37.0", "@algolia/client-analytics": "5.37.0", "@algolia/client-common": "5.37.0", "@algolia/client-insights": "5.37.0", "@algolia/client-personalization": "5.37.0", "@algolia/client-query-suggestions": "5.37.0", "@algolia/client-search": "5.37.0", "@algolia/ingestion": "1.37.0", "@algolia/monitoring": "1.37.0", "@algolia/recommend": "5.37.0", "@algolia/requester-browser-xhr": "5.37.0", "@algolia/requester-fetch": "5.37.0", "@algolia/requester-node-http": "5.37.0" } }, "sha512-y7gau/ZOQDqoInTQp0IwTOjkrHc4Aq4R8JgpmCleFwiLl+PbN2DMWoDUWZnrK8AhNJwT++dn28Bt4NZYNLAmuA=="],
+    "algoliasearch": ["algoliasearch@5.39.0", "", { "dependencies": { "@algolia/abtesting": "1.5.0", "@algolia/client-abtesting": "5.39.0", "@algolia/client-analytics": "5.39.0", "@algolia/client-common": "5.39.0", "@algolia/client-insights": "5.39.0", "@algolia/client-personalization": "5.39.0", "@algolia/client-query-suggestions": "5.39.0", "@algolia/client-search": "5.39.0", "@algolia/ingestion": "1.39.0", "@algolia/monitoring": "1.39.0", "@algolia/recommend": "5.39.0", "@algolia/requester-browser-xhr": "5.39.0", "@algolia/requester-fetch": "5.39.0", "@algolia/requester-node-http": "5.39.0" } }, "sha512-DzTfhUxzg9QBNGzU/0kZkxEV72TeA4MmPJ7RVfLnQwHNhhliPo7ynglEWJS791rNlLFoTyrKvkapwr/P3EXV9A=="],
 
     "ansi-escapes": ["ansi-escapes@7.1.1", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q=="],
 
@@ -325,7 +327,7 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "birpc": ["birpc@2.5.0", "", {}, "sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ=="],
+    "birpc": ["birpc@2.6.1", "", {}, "sha512-LPnFhlDpdSH6FJhJyn4M0kFO7vtQ5iPw24FnG0y21q09xC7e8+1LeR31S1MAIrDAHp4m7aas4bEkTDTvMAtebQ=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
@@ -365,7 +367,7 @@
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
-    "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -385,7 +387,7 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.36.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.0", "@eslint/config-helpers": "^0.3.1", "@eslint/core": "^0.15.2", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.36.0", "@eslint/plugin-kit": "^0.3.5", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ=="],
+    "eslint": ["eslint@9.37.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.0", "@eslint/config-helpers": "^0.4.0", "@eslint/core": "^0.16.0", "@eslint/eslintrc": "^3.3.1", "@eslint/js": "9.37.0", "@eslint/plugin-kit": "^0.4.0", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "@types/json-schema": "^7.0.15", "ajv": "^6.12.4", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.2", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig=="],
 
     "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
 
@@ -445,7 +447,7 @@
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
-    "hono": ["hono@4.9.9", "", {}, "sha512-Hxw4wT6zjJGZJdkJzAx9PyBdf7ZpxaTSA0NfxqjLghwMrLBX8p33hJBzoETRakF3UJu6OdNQBZAlNSkGqKFukw=="],
+    "hono": ["hono@4.9.10", "", {}, "sha512-AlI15ijFyKTXR7eHo7QK7OR4RoKIedZvBuRjO8iy4zrxvlY5oFCdiRG/V/lFJHCNXJ0k72ATgnyzx8Yqa5arug=="],
 
     "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 
@@ -495,7 +497,7 @@
 
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
-    "magic-string": ["magic-string@0.30.18", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ=="],
+    "magic-string": ["magic-string@0.30.19", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw=="],
 
     "mark.js": ["mark.js@8.11.1", "", {}, "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="],
 
@@ -519,7 +521,7 @@
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
-    "minisearch": ["minisearch@7.1.2", "", {}, "sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA=="],
+    "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
@@ -557,7 +559,7 @@
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
-    "preact": ["preact@10.27.1", "", {}, "sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ=="],
+    "preact": ["preact@10.27.2", "", {}, "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -583,7 +585,7 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
-    "rollup": ["rollup@4.50.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.50.0", "@rollup/rollup-android-arm64": "4.50.0", "@rollup/rollup-darwin-arm64": "4.50.0", "@rollup/rollup-darwin-x64": "4.50.0", "@rollup/rollup-freebsd-arm64": "4.50.0", "@rollup/rollup-freebsd-x64": "4.50.0", "@rollup/rollup-linux-arm-gnueabihf": "4.50.0", "@rollup/rollup-linux-arm-musleabihf": "4.50.0", "@rollup/rollup-linux-arm64-gnu": "4.50.0", "@rollup/rollup-linux-arm64-musl": "4.50.0", "@rollup/rollup-linux-loongarch64-gnu": "4.50.0", "@rollup/rollup-linux-ppc64-gnu": "4.50.0", "@rollup/rollup-linux-riscv64-gnu": "4.50.0", "@rollup/rollup-linux-riscv64-musl": "4.50.0", "@rollup/rollup-linux-s390x-gnu": "4.50.0", "@rollup/rollup-linux-x64-gnu": "4.50.0", "@rollup/rollup-linux-x64-musl": "4.50.0", "@rollup/rollup-openharmony-arm64": "4.50.0", "@rollup/rollup-win32-arm64-msvc": "4.50.0", "@rollup/rollup-win32-ia32-msvc": "4.50.0", "@rollup/rollup-win32-x64-msvc": "4.50.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw=="],
+    "rollup": ["rollup@4.52.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.4", "@rollup/rollup-android-arm64": "4.52.4", "@rollup/rollup-darwin-arm64": "4.52.4", "@rollup/rollup-darwin-x64": "4.52.4", "@rollup/rollup-freebsd-arm64": "4.52.4", "@rollup/rollup-freebsd-x64": "4.52.4", "@rollup/rollup-linux-arm-gnueabihf": "4.52.4", "@rollup/rollup-linux-arm-musleabihf": "4.52.4", "@rollup/rollup-linux-arm64-gnu": "4.52.4", "@rollup/rollup-linux-arm64-musl": "4.52.4", "@rollup/rollup-linux-loong64-gnu": "4.52.4", "@rollup/rollup-linux-ppc64-gnu": "4.52.4", "@rollup/rollup-linux-riscv64-gnu": "4.52.4", "@rollup/rollup-linux-riscv64-musl": "4.52.4", "@rollup/rollup-linux-s390x-gnu": "4.52.4", "@rollup/rollup-linux-x64-gnu": "4.52.4", "@rollup/rollup-linux-x64-musl": "4.52.4", "@rollup/rollup-openharmony-arm64": "4.52.4", "@rollup/rollup-win32-arm64-msvc": "4.52.4", "@rollup/rollup-win32-ia32-msvc": "4.52.4", "@rollup/rollup-win32-x64-gnu": "4.52.4", "@rollup/rollup-win32-x64-msvc": "4.52.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
@@ -633,9 +635,9 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "typescript-eslint": ["typescript-eslint@8.45.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.45.0", "@typescript-eslint/parser": "8.45.0", "@typescript-eslint/typescript-estree": "8.45.0", "@typescript-eslint/utils": "8.45.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-qzDmZw/Z5beNLUrXfd0HIW6MzIaAV5WNDxmMs9/3ojGOpYavofgNAAD/nC6tGV2PczIi0iw8vot2eAe/sBn7zg=="],
+    "typescript-eslint": ["typescript-eslint@8.46.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.46.0", "@typescript-eslint/parser": "8.46.0", "@typescript-eslint/typescript-estree": "8.46.0", "@typescript-eslint/utils": "8.46.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-6+ZrB6y2bT2DX3K+Qd9vn7OFOJR+xSLDj+Aw/N3zBwUt27uTw2sw2TE2+UcY1RiyBZkaGbTkVg9SSdPNUG6aUw=="],
 
-    "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
+    "undici-types": ["undici-types@7.14.0", "", {}, "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA=="],
 
     "unist-util-is": ["unist-util-is@6.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw=="],
 
@@ -657,11 +659,11 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@5.4.19", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA=="],
+    "vite": ["vite@5.4.20", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g=="],
 
     "vitepress": ["vitepress@1.6.4", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg=="],
 
-    "vue": ["vue@3.5.21", "", { "dependencies": { "@vue/compiler-dom": "3.5.21", "@vue/compiler-sfc": "3.5.21", "@vue/runtime-dom": "3.5.21", "@vue/server-renderer": "3.5.21", "@vue/shared": "3.5.21" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA=="],
+    "vue": ["vue@3.5.22", "", { "dependencies": { "@vue/compiler-dom": "3.5.22", "@vue/compiler-sfc": "3.5.22", "@vue/runtime-dom": "3.5.22", "@vue/server-renderer": "3.5.22", "@vue/shared": "3.5.22" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -673,7 +675,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.1.11", "", {}, "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg=="],
+    "zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/client/README.md
+++ b/client/README.md
@@ -10,7 +10,6 @@ Type-safe WebSocket client for browsers with schema-based message validation.
 - 🔐 **Auth support** – Query param or WebSocket protocol attachment
 - ⏱️ **Request/response** – RPC-style messaging with correlation tracking
 - 🎯 **Multi-handler** – Register multiple handlers per message type
-- 🪶 **Tiny bundle** – ~3KB min+gz (without validator)
 
 ## Usage
 
@@ -19,18 +18,19 @@ Type-safe WebSocket client for browsers with schema-based message validation.
 ```typescript
 import { z } from "zod";
 import { createMessageSchema } from "bun-ws-router/zod";
-import { createClient } from "bun-ws-router/client";
+import { createClient } from "bun-ws-router/zod/client"; // ✅ Typed client
 
 // Create schemas (shared with server)
 const { messageSchema } = createMessageSchema(z);
 const Hello = messageSchema("HELLO", { name: z.string() });
 const HelloOk = messageSchema("HELLO_OK", { text: z.string() });
 
-// Create client
+// Create typed client (use /zod/client or /valibot/client for type inference)
 const client = createClient({ url: "wss://example.com/ws" });
 
-// Register handlers
+// Register handlers with full type inference
 client.on(HelloOk, (msg) => {
+  // ✅ msg.payload.text is typed as string (no manual type assertions needed)
   console.log("Server says:", msg.payload.text);
 });
 
@@ -38,6 +38,8 @@ client.on(HelloOk, (msg) => {
 await client.connect();
 client.send(Hello, { name: "Alice" });
 ```
+
+> **Typed vs Generic Client**: Use `/zod/client` or `/valibot/client` for automatic type inference in handlers. The generic client at `/client` requires manual type assertions and is only needed for custom validators.
 
 ### Request/Response
 

--- a/client/normalize.ts
+++ b/client/normalize.ts
@@ -35,7 +35,7 @@ export function normalizeOutboundMeta(
   }
 
   // Strip reserved server-only keys (security boundary)
-  for (const key of RESERVED_META_KEYS) {
+  for (const key of Array.from(RESERVED_META_KEYS)) {
     Reflect.deleteProperty(meta, key);
   }
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,12 +9,53 @@ export default defineConfig({
   title: "Bun WebSocket Router",
   description:
     "Schema-first WebSocket message router for Bun with TypeScript validation",
+  lang: "en-US",
+  lastUpdated: true,
+  cleanUrls: true,
+  sitemap: {
+    hostname: "https://kriasoft.com/bun-ws-router/",
+    lastmodDateOnly: false,
+  },
+  head: [
+    ["link", { rel: "icon", href: "/bun-ws-router/favicon.ico" }],
+    ["meta", { name: "theme-color", content: "#3c8772" }],
+    ["meta", { property: "og:type", content: "website" }],
+    ["meta", { property: "og:locale", content: "en" }],
+    [
+      "meta",
+      {
+        property: "og:title",
+        content: "Bun WebSocket Router | Schema-First WebSocket Routing",
+      },
+    ],
+    ["meta", { property: "og:site_name", content: "Bun WebSocket Router" }],
+    [
+      "meta",
+      { property: "og:url", content: "https://kriasoft.com/bun-ws-router/" },
+    ],
+    [
+      "meta",
+      {
+        property: "og:image",
+        content: "https://kriasoft.com/bun-ws-router/og-image.webp",
+      },
+    ],
+  ],
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: "Home", link: "/" },
       { text: "Docs", link: "/getting-started" },
     ],
+
+    search: {
+      provider: "local",
+    },
+
+    editLink: {
+      pattern: "https://github.com/kriasoft/bun-ws-router/edit/main/docs/:path",
+      text: "Edit this page on GitHub",
+    },
 
     sidebar: [
       {
@@ -39,10 +80,42 @@ export default defineConfig({
           { text: "Advanced", link: "/client-advanced" },
         ],
       },
+      {
+        text: "For Developers",
+        items: [
+          {
+            text: "Specifications",
+            link: "https://github.com/kriasoft/bun-ws-router/tree/main/specs",
+          },
+          {
+            text: "Architecture Decisions",
+            link: "https://github.com/kriasoft/bun-ws-router/blob/main/specs/adrs.md",
+          },
+          {
+            text: "Contributing",
+            link: "https://github.com/kriasoft/bun-ws-router/blob/main/.github/CONTRIBUTING.md",
+          },
+          {
+            text: "Security Policy",
+            link: "https://github.com/kriasoft/bun-ws-router/blob/main/.github/SECURITY.md",
+          },
+          {
+            text: "Sponsor",
+            link: "https://github.com/sponsors/koistya",
+          },
+        ],
+      },
     ],
 
     socialLinks: [
       { icon: "github", link: "https://github.com/kriasoft/bun-ws-router" },
     ],
+
+    footer: {
+      message:
+        'Released under the <a href="https://github.com/kriasoft/bun-ws-router/blob/main/LICENSE">MIT License</a>.',
+      copyright:
+        'Copyright © 2025-present <a href="https://kriasoft.com" target="_self">Kriasoft</a> · Created by <a href="https://github.com/koistya">Konstantin Tarkus</a>',
+    },
   },
 });

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,19 +23,23 @@ new WebSocketRouter<TData = unknown>()
 Register a handler for new connections.
 
 ```typescript
-onOpen(handler: (ws: ServerWebSocket<WebSocketData<TData>>) => void): this
+onOpen(handler: (context: OpenHandlerContext<TData>) => void | Promise<void>): this
 ```
 
 **Parameters:**
 
 - `handler` - Function called when a client connects
-- `ws` - The WebSocket instance with typed data
+- `context.ws` - The WebSocket instance with typed data
+- `context.send` - Type-safe send function
 
 **Example:**
 
 ```typescript
-router.onOpen((ws) => {
-  console.log(`Client ${ws.data.clientId} connected`);
+router.onOpen((ctx) => {
+  console.log(`Client ${ctx.ws.data.clientId} connected`);
+
+  // ctx.send() auto-adds timestamp to meta
+  ctx.send(WelcomeMessage, { text: "Welcome!" });
 });
 ```
 
@@ -58,9 +62,13 @@ onMessage<TPayload>(
 **Example:**
 
 ```typescript
+import { publish } from "bun-ws-router/zod/publish";
+
 router.onMessage(ChatMessage, async (ctx) => {
   await saveMessage(ctx.payload);
-  ctx.publish("chat", ChatMessage, ctx.payload);
+
+  // publish() validates and auto-adds timestamp before broadcasting
+  publish(ctx.ws, "chat", ChatMessage, ctx.payload);
 });
 ```
 
@@ -70,47 +78,35 @@ Register a handler for disconnections.
 
 ```typescript
 onClose(
-  handler: (
-    ws: ServerWebSocket<WebSocketData<TData>>,
-    code: number,
-    reason: string
-  ) => void
+  handler: (context: CloseHandlerContext<TData>) => void | Promise<void>
 ): this
 ```
 
 **Parameters:**
 
 - `handler` - Function called when a client disconnects
-- `ws` - The WebSocket instance
-- `code` - Close code
-- `reason` - Close reason
+- `context.ws` - The WebSocket instance with typed data
+- `context.code` - WebSocket close code
+- `context.reason` - Optional close reason string
+- `context.send` - Type-safe send function (for cleanup broadcasts only, cannot send to closed connection)
 
 **Example:**
 
 ```typescript
-router.onClose((ws, code, reason) => {
-  console.log(`Client ${ws.data.clientId} disconnected: ${code} ${reason}`);
+router.onClose((ctx) => {
+  console.log(
+    `Client ${ctx.ws.data.clientId} disconnected: ${ctx.code} ${ctx.reason || "N/A"}`,
+  );
+
+  // Clean up user from rooms
+  const rooms = getUserRooms(ctx.ws.data.clientId);
+  rooms.forEach((roomId) => {
+    removeUserFromRoom(ctx.ws.data.clientId, roomId);
+  });
 });
 ```
 
-#### `onError(handler)`
-
-Register a global error handler.
-
-```typescript
-onError(
-  handler: (
-    ws: ServerWebSocket<WebSocketData<TData>>,
-    error: Error
-  ) => void
-): this
-```
-
-**Parameters:**
-
-- `handler` - Function called on unhandled errors
-- `ws` - The WebSocket instance
-- `error` - The error object
+**Note:** The `send` function is provided in the context but can only be used for broadcasting to other clients via `publish()`. Sending directly to the disconnected client (`ctx.ws`) will fail since the connection is closed.
 
 #### `addRoutes(router)`
 
@@ -212,7 +208,7 @@ function messageSchema<TType extends string, TPayload>(
 function messageSchema<TType extends string, TPayload, TMeta>(
   type: TType,
   schema: Schema<TPayload>,
-  options: { meta?: Schema<TMeta> },
+  metaSchema: Schema<TMeta>,
 ): MessageSchema<TPayload>;
 ```
 
@@ -220,7 +216,7 @@ function messageSchema<TType extends string, TPayload, TMeta>(
 
 - `type` - Unique message type identifier
 - `schema` - Zod or Valibot schema for payload validation
-- `options.meta` - Optional schema for custom metadata
+- `metaSchema` - Optional schema for custom metadata (third parameter, not wrapped in options)
 
 **Returns:** MessageSchema object with type information
 
@@ -259,24 +255,42 @@ Context object passed to message handlers.
 
 ```typescript
 interface MessageContext<TPayload, TData = unknown> {
-  ws: ServerWebSocket<WebSocketData<TData>>;
-  clientId: string;
-  payload: TPayload;
+  ws: ServerWebSocket<TData>;
+  type: string;
+  meta: {
+    timestamp?: number;
+    correlationId?: string;
+    [key: string]: unknown;
+  };
+  receivedAt: number;
+  send: SendFunction;
+  payload?: TPayload; // Only present if schema defines payload
 }
 ```
 
-- `ws` - The WebSocket instance
-- `clientId` - Unique client identifier
-- `payload` - Validated message payload
+- `ws` - WebSocket instance (always includes `ctx.ws.data.clientId`)
+- `type` - Message type literal
+- `meta` - Validated metadata (timestamp, correlationId, custom fields)
+- `receivedAt` - Server timestamp (authoritative for server logic)
+- `send` - Type-safe send function
+- `payload` - Validated payload (only exists if schema defines it)
+
+**Key Points:**
+
+- Client ID: `ctx.ws.data.clientId` (UUID v7, always present)
+- Server timestamp: `ctx.receivedAt` (use for rate limiting, ordering, TTL)
+- Client timestamp: `ctx.meta.timestamp` (use for UI display only)
+- Publishing: Use `publish()` helper (see below)
+- Subscriptions: `ctx.ws.subscribe(topic)` / `ctx.ws.unsubscribe(topic)`
 
 ### Methods
 
-#### `send(schema, payload?)`
+#### `send(schema, payload?, meta?)`
 
 Send a message to the current client.
 
 ```typescript
-send<T>(schema: MessageSchema<T>, payload?: T): void
+send<T>(schema: MessageSchema<T>, payload?: T, meta?: Record<string, unknown>): void
 send(message: Message): void
 ```
 
@@ -292,86 +306,164 @@ ctx.send(ErrorMessage, {
 // Using raw message
 ctx.send({
   type: "PONG",
-  meta: { clientId: ctx.clientId, timestamp: Date.now() },
+  meta: { timestamp: Date.now() },
 });
 ```
 
-#### `publish(topic, schema, payload)`
+## Helper Functions
 
-Broadcast a message to all subscribers of a topic.
+### `publish()`
+
+Type-safe helper for broadcasting messages to WebSocket topics.
+
+**Import:**
+
+```typescript
+import { publish } from "bun-ws-router/zod/publish";
+// or
+import { publish } from "bun-ws-router/valibot/publish";
+```
+
+**Signature:**
 
 ```typescript
 publish<T>(
+  ws: ServerWebSocket,
   topic: string,
   schema: MessageSchema<T>,
-  payload: T
-): void
-
-publish(topic: string, message: Message): void
+  payload: T,
+  metaOrOpts?: Partial<MessageMetadata> | { origin?: string; key?: string }
+): boolean
 ```
+
+**Parameters:**
+
+- `ws` - WebSocket instance (usually `ctx.ws`)
+- `topic` - Topic name to publish to
+- `schema` - Message schema for validation
+- `payload` - Message payload data
+- `metaOrOpts` - Optional metadata or options object:
+  - As metadata: `{ correlationId?: string, ... }` - Custom metadata fields
+  - As options: `{ origin?: string, key?: string }` - Sender tracking configuration
+
+**Returns:** `true` if message was validated and published successfully, `false` otherwise
 
 **Examples:**
 
 ```typescript
-// Using schema
-ctx.publish("room:123", ChatMessage, {
-  text: "Hello everyone!",
-  roomId: "123",
+import { publish } from "bun-ws-router/zod/publish";
+
+// Basic publish with type safety
+router.onMessage(ChatMessage, (ctx) => {
+  publish(ctx.ws, "room:123", ChatMessage, {
+    text: "Hello everyone!",
+    roomId: "123",
+  });
 });
 
-// Using raw message
-ctx.publish("notifications", {
-  type: "NOTIFICATION",
-  payload: { message: "New update available" },
-});
+// Publish with custom metadata
+publish(
+  ctx.ws,
+  "notifications",
+  NotificationMessage,
+  { text: "Update available" },
+  { correlationId: "req-123" },
+);
+
+// Publish with sender tracking (origin option)
+// Automatically injects senderId from ws.data.userId
+publish(
+  ctx.ws,
+  "room:123",
+  ChatMessage,
+  { text: "Hello" },
+  { origin: "userId" }, // Looks up ws.data.userId and adds to meta.senderId
+);
+
+// Custom sender field name
+publish(
+  ctx.ws,
+  "room:123",
+  ChatMessage,
+  { text: "Hello" },
+  { origin: "userId", key: "authorId" }, // Adds to meta.authorId instead
+);
 ```
 
-#### `subscribe(topic)`
+**Origin Option:**
 
-Subscribe to a topic.
+The `origin` option enables automatic sender tracking by extracting a value from `ws.data` and injecting it into the message metadata:
+
+- `origin: "userId"` - Reads `ws.data.userId` and adds it to `meta.senderId`
+- `key: "authorId"` - Uses `meta.authorId` instead of default `meta.senderId`
+
+This is useful for:
+
+- Tracking who sent a broadcast message
+- Filtering messages by sender
+- Implementing sender-based permissions
+
+**Why is `publish()` standalone?**
+
+The `publish()` helper is a standalone function (not `ctx.publish()`) because:
+
+- **Validation** - Validates messages against schema before broadcasting (security boundary)
+- **Auto-timestamp** - Automatically adds `timestamp` to `meta` (like `ctx.send()`)
+- **Type safety** - Full TypeScript inference for payload and meta
+- **Return value** - Returns `boolean` for error handling (true if any client received message)
+
+For raw publishing without validation or timestamps, use `ctx.ws.publish()` directly.
+
+## WebSocket Methods
+
+These methods are available on `ctx.ws` (Bun's ServerWebSocket):
+
+### `subscribe()`
+
+Subscribe to topics for receiving broadcasts.
 
 ```typescript
-subscribe(...topics: string[]): void
+ctx.ws.subscribe(...topics: string[]): void
 ```
 
 **Example:**
 
 ```typescript
-ctx.subscribe("room:123", "notifications");
+ctx.ws.subscribe("room:123", "notifications");
 ```
 
-#### `unsubscribe(topic)`
+### `unsubscribe()`
 
 Unsubscribe from a topic.
 
 ```typescript
-unsubscribe(...topics: string[]): void
+ctx.ws.unsubscribe(...topics: string[]): void
 ```
 
 **Example:**
 
 ```typescript
-ctx.unsubscribe("room:123");
+ctx.ws.unsubscribe("room:123");
 ```
 
-#### `getData()` / `setData()`
+### Custom Connection Data
 
-Get or set custom connection data.
+Access and modify custom connection data via `ctx.ws.data`:
 
 ```typescript
-getData<T = TData>(): T
-setData<T = TData>(data: T): void
+// Access custom data (read)
+const userId = ctx.ws.data.userId;
+const roles = ctx.ws.data.roles;
+
+// Access clientId (always present, UUID v7)
+const clientId = ctx.ws.data.clientId;
+
+// Modify custom data (write)
+ctx.ws.data.isAuthenticated = true;
+ctx.ws.data.lastActivity = Date.now();
 ```
 
-**Example:**
-
-```typescript
-// Set user data
-ctx.setData({ userId: "123", roles: ["admin"] });
-
-// Get user data
-const userData = ctx.getData<{ userId: string; roles: string[] }>();
-```
+**Note:** The `clientId` field is automatically generated (UUID v7) by the router during WebSocket upgrade and is always present in `ws.data`.
 
 ## createMessage() Helper
 
@@ -427,46 +519,6 @@ const tracked = createMessage(
   { action: "fetch" },
   { correlationId: "req-123" },
 );
-```
-
-## publish() Helper
-
-Standalone function for publishing messages with validation.
-
-```typescript
-function publish<T>(
-  server: Server,
-  topic: string,
-  schema: MessageSchema<T>,
-  payload: T,
-): void;
-```
-
-**Parameters:**
-
-- `server` - Bun server instance
-- `topic` - Topic to publish to
-- `schema` - Message schema for validation
-- `payload` - Message payload
-
-**Example:**
-
-```typescript
-import { publish } from "bun-ws-router/zod/publish";
-// or
-import { publish } from "bun-ws-router/valibot/publish";
-
-// In an HTTP endpoint
-app.post("/broadcast", (req) => {
-  const { message } = await req.json();
-
-  publish(server, "global", AnnouncementMessage, {
-    text: message,
-    priority: "high",
-  });
-
-  return new Response("Broadcasted");
-});
 ```
 
 ## ErrorCode and ErrorMessage
@@ -548,8 +600,7 @@ ctx.send(ErrorMessage, {
 interface Message<T = unknown> {
   type: string;
   meta: {
-    clientId: string;
-    timestamp: number;
+    timestamp?: number;
     correlationId?: string;
   };
   payload?: T;
@@ -560,9 +611,8 @@ interface Message<T = unknown> {
 
 ```typescript
 interface WebSocketData<T = unknown> {
-  clientId: string;
-  user?: T;
-}
+  clientId: string; // UUID v7, auto-generated by router
+} & T
 ```
 
 ### MessageSchema

--- a/docs/client-advanced.md
+++ b/docs/client-advanced.md
@@ -9,7 +9,7 @@ The client automatically reconnects on connection loss with exponential backoff.
 ### Basic Reconnection
 
 ```typescript
-import { createClient } from "bun-ws-router/client";
+import { createClient } from "bun-ws-router/zod/client"; // ✅ Typed client
 
 const client = createClient({
   url: "wss://api.example.com/ws",
@@ -256,7 +256,8 @@ useEffect(() => {
       const reply = await client.request(GetData, { id: 123 }, GetDataOk, {
         signal: controller.signal,
       });
-      setData(reply.payload);
+      // Update state with the reply payload
+      setState(reply.payload);
     } catch (err) {
       if (!(err instanceof StateError)) {
         console.error(err);
@@ -577,7 +578,7 @@ client.onUnhandled((msg) => {
 Use `wsFactory` for dependency injection:
 
 ```typescript
-import { createClient } from "bun-ws-router/client";
+import { createClient } from "bun-ws-router/zod/client";
 
 class FakeWebSocket {
   readyState = WebSocket.CONNECTING;

--- a/docs/client-auth.md
+++ b/docs/client-auth.md
@@ -5,7 +5,7 @@ The WebSocket client supports flexible token-based authentication with automatic
 ## Quick Start
 
 ```typescript
-import { createClient } from "bun-ws-router/client";
+import { createClient } from "bun-ws-router/zod/client"; // ✅ Typed client
 
 const client = createClient({
   url: "wss://api.example.com/ws",
@@ -284,9 +284,10 @@ Bun.serve({
 
     const userId = getUserIdFromToken(token);
 
+    // router.upgrade() auto-generates clientId (UUID v7) and returns Response
     return router.upgrade(req, {
       server,
-      data: { userId }, // Attach user data
+      data: { userId },
     });
   },
   websocket: router.websocket,
@@ -311,6 +312,7 @@ Bun.serve({
 
     const userId = getUserIdFromToken(token);
 
+    // router.upgrade() auto-generates clientId (UUID v7) and returns Response
     return router.upgrade(req, {
       server,
       data: { userId },

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 layout: home
 
 hero:
-  name: "Schema-First WebSocket Routing"
+  name: "Type-Safe WebSocket Routing"
   # text: "Type-safe WebSocket routing for Bun"
   tagline: Type-safe message routing for Bun's WebSocket server that complements native PubSub and connection handling
   actions:
@@ -29,7 +29,7 @@ features:
     details: Simple API with powerful features like error boundaries, connection metadata, and async handlers
   - icon: 📦
     title: Lightweight
-    details: Choose Valibot for 90% smaller bundles or Zod for familiar syntax. Core logic shared between adapters
+    details: Choose Valibot for significantly smaller bundles or Zod for familiar syntax. Core logic shared between adapters
   - icon: 🚀
     title: Production Ready
     details: Built-in error handling, authentication patterns, and room broadcasting for real-world applications

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -35,6 +35,13 @@ export default defineConfig([
     },
   },
   {
+    name: "example-files-relaxed",
+    files: ["examples/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": "off",
+    },
+  },
+  {
     name: "prettier-overrides",
     extends: [prettier],
   },

--- a/examples/typed-client-usage.ts
+++ b/examples/typed-client-usage.ts
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2025-present Kriasoft
+// SPDX-License-Identifier: MIT
+
+/**
+ * Example demonstrating typed WebSocket client usage with Zod schemas.
+ *
+ * This example shows:
+ * - Full type inference in message handlers
+ * - Payload conditional typing (with/without payload)
+ * - Extended meta field support
+ * - Request/response patterns
+ *
+ * @see specs/adrs.md#ADR-002 - Type override implementation
+ * @see specs/client.md - Full client API
+ */
+
+import { z } from "zod";
+import { createMessageSchema } from "../zod/index.js";
+import { createClient } from "../zod/client.js";
+
+// Create schema factory
+const { messageSchema } = createMessageSchema(z);
+
+// Define message schemas
+const Hello = messageSchema("HELLO", { name: z.string() });
+const HelloOk = messageSchema("HELLO_OK", { text: z.string() });
+const Logout = messageSchema("LOGOUT"); // No payload
+const LogoutOk = messageSchema("LOGOUT_OK"); // No payload
+const ChatMessage = messageSchema(
+  "CHAT",
+  { text: z.string() },
+  { roomId: z.string() }, // Required extended meta
+);
+
+// Create typed client
+const client = createClient({
+  url: "wss://api.example.com",
+  autoConnect: true,
+  reconnect: { enabled: true },
+});
+
+// ============================================================================
+// Type-Safe Message Handlers
+// ============================================================================
+
+// ✅ Handler receives fully typed message
+client.on(HelloOk, (msg) => {
+  // msg.type is "HELLO_OK" (literal type)
+  console.log(`Type: ${msg.type}`);
+
+  // msg.payload is { text: string }
+  console.log(`Text: ${msg.payload.text.toUpperCase()}`);
+
+  // msg.meta has timestamp and correlationId
+  if (msg.meta.timestamp) {
+    console.log(`Received at: ${new Date(msg.meta.timestamp).toISOString()}`);
+  }
+});
+
+// ✅ No-payload schema - handler has no payload access
+client.on(Logout, (msg) => {
+  console.log(`User logged out: ${msg.type}`);
+
+  // msg.payload does not exist (compile error if accessed)
+});
+
+// ✅ Extended meta - required field enforced
+client.on(ChatMessage, (msg) => {
+  // msg.meta.roomId is string (required field)
+  console.log(`Message in room ${msg.meta.roomId}: ${msg.payload.text}`);
+});
+
+// ============================================================================
+// Type-Safe Sending
+// ============================================================================
+
+async function sendExamples() {
+  await client.connect();
+
+  // ✅ Send with payload (payload required)
+  client.send(Hello, { name: "Alice" });
+
+  // ❌ Compile error - payload required but missing
+  // client.send(Hello); // Type error!
+
+  // ✅ Send without payload (payload omitted)
+  client.send(Logout);
+
+  // ❌ Compile error - payload should not be provided
+  // client.send(Logout, {}); // Type error!
+
+  // ✅ Send with extended meta
+  client.send(
+    ChatMessage,
+    { text: "Hello everyone!" },
+    { meta: { roomId: "general" } },
+  );
+
+  // ❌ Compile error - opts.meta.roomId is required
+  // client.send(ChatMessage, { text: "Hello" }); // Type error: meta.roomId is required
+}
+
+// ============================================================================
+// Type-Safe Request/Response
+// ============================================================================
+
+async function requestExamples() {
+  await client.connect();
+
+  // ✅ Request with typed reply (with payload)
+  const reply = await client.request(Hello, { name: "Bob" }, HelloOk, {
+    timeoutMs: 5000,
+  });
+
+  // reply is fully typed: { type: "HELLO_OK", meta: {...}, payload: { text: string } }
+  console.log(`Server replied: ${reply.payload.text}`);
+
+  // ✅ Request without payload (no-payload schema)
+  const logoutReply = await client.request(Logout, LogoutOk, {
+    timeoutMs: 5000,
+  });
+
+  // logoutReply is typed: { type: "LOGOUT_OK", meta: {...} }
+  console.log(`Logged out at: ${logoutReply.type}`);
+
+  // ❌ Compile error - no-payload schema doesn't accept payload parameter
+  // const invalidReply = await client.request(Logout, {}, LogoutOk, { timeoutMs: 5000 });
+
+  // ✅ Request with AbortSignal
+  const controller = new AbortController();
+
+  const promise = client.request(Hello, { name: "Charlie" }, HelloOk, {
+    signal: controller.signal,
+  });
+
+  // Cancel if needed
+  // controller.abort();
+
+  try {
+    const result = await promise;
+    console.log(result.payload.text);
+  } catch (err) {
+    console.error("Request failed:", err);
+  }
+}
+
+// ============================================================================
+// Generic Client (Fallback - No Type Inference)
+// ============================================================================
+
+// For comparison: generic client requires manual type assertions
+import { createClient as createGenericClient } from "../client/index.js";
+import type { InferMessage } from "../zod/types.js";
+
+const genericClient = createGenericClient({ url: "wss://api.example.com" });
+
+genericClient.on(HelloOk, (msg) => {
+  // ⚠️ msg is unknown - requires manual type assertion
+  const typed = msg as InferMessage<typeof HelloOk>;
+  console.log(typed.payload.text);
+});
+
+// ============================================================================
+// Run Examples (Type Demonstration Only)
+// ============================================================================
+
+// Note: These functions are for demonstrating compile-time type safety.
+// They won't run successfully without a real WebSocket server.
+// Uncomment to test with a live server:
+
+// sendExamples().catch(console.error);
+// requestExamples().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "bun-ws-router",
-  "version": "0.5.0",
-  "description": "A simple and efficient WebSocket router for Bun with Zod/Valibot message validation.",
+  "version": "0.6.0",
+  "description": "Lightweight client/server WebSocket router for Bun with type-safe Zod/Valibot validation.",
   "keywords": [
     "broadcast",
     "bun",
+    "client",
     "framework",
     "handler",
     "hono",
@@ -14,9 +15,11 @@
     "realtime",
     "router",
     "schema",
+    "server",
     "socket",
     "socketio",
     "type-safe",
+    "typesafe",
     "typescript",
     "valibot",
     "validation",
@@ -36,7 +39,7 @@
   "contributors": [
     {
       "name": "Konstantin Tarkus",
-      "url": "https://github.com/koistya"
+      "url": "https://github.com/sponsors/koistya"
     }
   ],
   "type": "module",
@@ -55,6 +58,14 @@
       "bun": "./valibot/index.ts",
       "types": "./dist/valibot/index.d.ts",
       "default": "./dist/valibot/index.js"
+    },
+    "./zod/client": {
+      "types": "./dist/zod/client.d.ts",
+      "default": "./dist/zod/client.js"
+    },
+    "./valibot/client": {
+      "types": "./dist/valibot/client.d.ts",
+      "default": "./dist/valibot/client.js"
     },
     "./client": {
       "types": "./dist/client/index.d.ts",
@@ -88,21 +99,21 @@
     }
   },
   "devDependencies": {
-    "@eslint/js": "^9.36.0",
+    "@eslint/js": "^9.37.0",
     "@types/bun": "^1.2.23",
     "eslint-config-prettier": "^10.1.8",
-    "eslint": "^9.36.0",
+    "eslint": "^9.37.0",
     "globals": "^16.4.0",
-    "hono": "^4.9.9",
+    "hono": "^4.9.10",
     "husky": "^9.1.7",
     "jiti": "^2.6.1",
     "lint-staged": "^16.2.3",
     "prettier": "^3.6.2",
-    "typescript-eslint": "^8.45.0",
+    "typescript-eslint": "^8.46.0",
     "typescript": "^5.9.3",
     "valibot": "^1.1.0",
     "vitepress": "^1.6.4",
-    "zod": "^4.1.11"
+    "zod": "^4.1.12"
   },
   "scripts": {
     "prepare": "husky",

--- a/specs/adrs.md
+++ b/specs/adrs.md
@@ -58,3 +58,159 @@ Accepts weaker typing in route composition for excellent IDE experience in prima
 1. **NEVER** access `ctx.payload` unless schema explicitly defines payload
 2. **ALWAYS** use `ctx.type` for message type
 3. Test inline handler inference with `expectTypeOf`
+
+## ADR-002: Typed Client Adapters via Type Overrides
+
+**Status**: ✅ Implemented
+
+### Context
+
+Use type overrides (not separate implementations) for validator-specific clients:
+
+- `/zod/client` exports `createClient()` returning `ZodWebSocketClient` (narrowed types)
+- `/valibot/client` exports `createClient()` returning `ValibotWebSocketClient` (narrowed types)
+- Generic client remains at `/client` (unchanged runtime, `unknown` handler types)
+
+### Analysis
+
+**Problem**: Generic client handlers infer as `unknown`, breaking type safety:
+
+```typescript
+// Generic client (before)
+import { createClient } from "bun-ws-router/client";
+client.on(HelloOk, (msg) => {
+  msg.type; // ❌ Type error: msg is unknown
+  msg.payload.text; // ❌ Type error: msg is unknown
+});
+```
+
+**Solution**: Validator-specific typed clients via type overrides (mirrors ADR-001 server pattern):
+
+- **Consistency**: Matches server's type override approach for inline handler inference
+- **Zero runtime cost**: Pure type casts at module boundary, no wrapper logic
+- **Maintainability**: Single client implementation, typed facades per validator
+- **DX**: Full inference without manual type guards or assertions
+
+### Implementation
+
+```typescript
+// zod/client.ts
+import { createClient as createGenericClient } from "bun-ws-router/client";
+import type { WebSocketClient } from "bun-ws-router/client";
+
+export interface ZodWebSocketClient
+  extends Omit<WebSocketClient, "on" | "send" | "request"> {
+  // Type-safe overrides with Zod inference
+  on<S extends ZodMessageSchema>(
+    schema: S,
+    handler: (msg: z.infer<S>) => void,
+  ): () => void;
+
+  send<S extends ZodMessageSchema>(
+    schema: S,
+    payload: InferPayload<S>,
+    opts?: { meta?: InferMeta<S>; correlationId?: string },
+  ): boolean;
+
+  request<S extends ZodMessageSchema, R extends ZodMessageSchema>(
+    schema: S,
+    payload: InferPayload<S>,
+    reply: R,
+    opts?: {
+      timeoutMs?: number;
+      meta?: InferMeta<S>;
+      correlationId?: string;
+      signal?: AbortSignal;
+    },
+  ): Promise<z.infer<R>>;
+}
+
+export function createClient(opts: ClientOptions): ZodWebSocketClient {
+  return createGenericClient(opts) as ZodWebSocketClient;
+}
+```
+
+Payload conditional typing uses overloads (like server) to enforce payload absence:
+
+```typescript
+// zod/types.ts
+export type InferPayload<S extends ZodMessageSchema> =
+  "payload" extends keyof S["shape"]
+    ? z.infer<S["shape"]["payload"]>
+    : never; // Not undefined - payload param must be omitted
+
+// Overloads in ZodWebSocketClient
+send<S extends ZodMessageSchema & { shape: { payload: any } }>(
+  schema: S,
+  payload: InferPayload<S>,
+  opts?: SendOptions<S>,
+): boolean;
+
+send<S extends ZodMessageSchema & { shape: { payload?: never } }>(
+  schema: S,
+  opts?: SendOptions<S>,
+): boolean;
+```
+
+### Trade-offs
+
+- **Breaking change**: Import paths change (`/client` → `/zod/client` or `/valibot/client`)
+- **LSP variance**: Type override creates same variance as server (ADR-001)
+- **Generic client remains**: Users with custom validators opt in via `/client` import
+- **Semver**: Requires major version bump (breaking change)
+
+### Migration Path
+
+**Before**:
+
+```typescript
+import { createClient } from "bun-ws-router/client";
+```
+
+**After**:
+
+```typescript
+// Zod users
+import { createClient } from "bun-ws-router/zod/client";
+
+// Valibot users
+import { createClient } from "bun-ws-router/valibot/client";
+
+// Custom validators (explicit opt-in)
+import { createClient } from "bun-ws-router/client";
+```
+
+**No other changes required** - runtime behavior identical, types now infer automatically.
+
+### Example: Full Type Inference
+
+```typescript
+// With typed client (after)
+import { z } from "zod";
+import { createMessageSchema } from "bun-ws-router/zod";
+import { createClient } from "bun-ws-router/zod/client";
+
+const { messageSchema } = createMessageSchema(z);
+const HelloOk = messageSchema("HELLO_OK", { text: z.string() });
+
+const client = createClient({ url: "wss://api.example.com" });
+
+client.on(HelloOk, (msg) => {
+  // ✅ msg fully typed: { type: "HELLO_OK", meta: MessageMeta, payload: { text: string } }
+  console.log(msg.type); // ✅ "HELLO_OK" (literal type)
+  console.log(msg.meta.timestamp); // ✅ number | undefined
+  console.log(msg.payload.text.toUpperCase()); // ✅ Type-safe string methods!
+});
+
+// Request/response also fully typed
+const reply = await client.request(Hello, { name: "Alice" }, HelloOk);
+console.log(reply.type); // ✅ "HELLO_OK" (literal)
+console.log(reply.payload.text); // ✅ string
+```
+
+### Constraints
+
+1. **ALWAYS** use typed clients (`/zod/client`, `/valibot/client`) for Zod/Valibot schemas
+2. **NEVER** use generic client (`/client`) unless implementing custom validator
+3. **ALWAYS** test inference with `expectTypeOf` (see @testing.md#client-type-inference)
+4. **ALWAYS** use overloads for payload conditional typing (not `undefined` parameter)

--- a/specs/constraints.md
+++ b/specs/constraints.md
@@ -16,18 +16,25 @@ Single source of truth for MUST/SHOULD/NEVER rules when working with `bun-ws-rou
 3. **NEVER** import from `"bun-ws-router"` root - use `/zod` or `/valibot`
 4. **NEVER** use deprecated `messageSchema` export - use factory pattern
    - Required to avoid dual package hazard with discriminated unions
+5. **ALWAYS** use typed clients for Zod/Valibot:
+   - `import { createClient } from "bun-ws-router/zod/client"`
+   - `import { createClient } from "bun-ws-router/valibot/client"`
+   - See @adrs.md#ADR-002 for type override pattern
+6. **NEVER** use generic client (`/client`) unless implementing custom validator
+   - Generic client handlers infer as `unknown` (requires manual type assertions)
 
 ### Security & Validation
 
-5. **NEVER** re-validate data inside handlers - trust schema validation
-6. **NEVER** access connection identity via `ctx.meta.clientId` - use `ctx.ws.data.clientId`
-7. **NEVER** allow clients to set reserved meta keys (`clientId`, `receivedAt`)
+7. **NEVER** re-validate data inside handlers - trust schema validation
+8. **NEVER** access connection identity via `ctx.meta.clientId` - use `ctx.ws.data.clientId`
+9. **NEVER** allow clients to set reserved meta keys (`clientId`, `receivedAt`)
    - Router MUST strip these during normalization BEFORE validation (security boundary)
    - Implementation: `shared/message.ts` in `MessageRouter.handleMessage()`
    - See @validation.md#normalization-rules for canonical code
-8. **ALWAYS** use strict schemas - reject unknown keys at root/meta/payload levels
-   - See @schema.md#Strict-Schemas for rationale
-   - See @validation.md#Strict-Mode-Enforcement for adapter requirements
+10. **ALWAYS** use strict schemas - reject unknown keys at root/meta/payload levels
+
+- See @schema.md#Strict-Schemas for rationale
+- See @validation.md#Strict-Mode-Enforcement for adapter requirements
 
 ## Required Patterns (ALWAYS Use)
 
@@ -83,27 +90,27 @@ Single source of truth for MUST/SHOULD/NEVER rules when working with `bun-ws-rou
 
 ### Error Handling
 
-9. **ALWAYS** wrap async operations in try/catch
-10. **ALWAYS** log errors with `clientId` context (`ctx.ws.data.clientId`)
-11. **ALWAYS** keep connections open on errors (handler must explicitly close)
+11. **ALWAYS** wrap async operations in try/catch
+12. **ALWAYS** log errors with `clientId` context (`ctx.ws.data.clientId`)
+13. **ALWAYS** keep connections open on errors (handler must explicitly close)
 
 ### Messaging
 
-12. **ALWAYS** use `ctx.send()` for type-safe message sending
-13. **ALWAYS** use `publish()` helper for validated broadcasting
+14. **ALWAYS** use `ctx.send()` for type-safe message sending
+15. **ALWAYS** use `publish()` helper for validated broadcasting
     - Validates before publishing to prevent malformed messages reaching subscribers
-14. **NEVER** inject `clientId` into message meta (inbound or outbound)
+16. **NEVER** inject `clientId` into message meta (inbound or outbound)
     - Connection identity is transport state (`ctx.ws.data.clientId`)
     - Use `publish(..., { origin: "userId" })` for sender tracking (see @pubsub.md#Origin-Option)
     - Injects as `meta.senderId` (not `clientId`) for application-level identity
     - `origin` is a `ws.data` field name; function extractors NOT supported (hot-path performance)
     - **No-op if `ws.data[origin]` is undefined**
-15. **ALWAYS** auto-inject `timestamp` in outbound messages (`ctx.send()` and `publish()`)
+17. **ALWAYS** auto-inject `timestamp` in outbound messages (`ctx.send()` and `publish()`)
 
 ### Lifecycle
 
-16. **ALWAYS** unsubscribe in `onClose()` handler
-17. **ALWAYS** store topic identifiers in `ctx.ws.data` for cleanup
+18. **ALWAYS** unsubscribe in `onClose()` handler
+19. **ALWAYS** store topic identifiers in `ctx.ws.data` for cleanup
 
 ## Type System Trade-offs
 

--- a/specs/router.md
+++ b/specs/router.md
@@ -84,8 +84,13 @@ router.onOpen((ctx) => {
 });
 
 router.onClose((ctx) => {
-  // ctx: { ws, code, reason?, send }
-  console.log("Client disconnected:", ctx.ws.data.clientId);
+  // ctx: { ws, code, reason, send }
+  console.log(
+    "Client disconnected:",
+    ctx.ws.data.clientId,
+    ctx.code,
+    ctx.reason,
+  );
 });
 ```
 

--- a/test/shared/lifecycle-handlers.test.ts
+++ b/test/shared/lifecycle-handlers.test.ts
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: 2025-present Kriasoft
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test";
+import { z } from "zod";
+import { WebSocketRouter } from "../../zod/router";
+import { createMessageSchema } from "../../zod/schema";
+
+const { messageSchema } = createMessageSchema(z);
+
+// Mock console methods to prevent noise during tests
+const originalConsoleLog = console.log;
+const originalConsoleWarn = console.warn;
+const originalConsoleError = console.error;
+
+beforeEach(() => {
+  console.log = mock(() => {
+    /* Mock implementation */
+  });
+  console.warn = mock(() => {
+    /* Mock implementation */
+  });
+  console.error = mock(() => {
+    /* Mock implementation */
+  });
+});
+
+afterEach(() => {
+  console.log = originalConsoleLog;
+  console.warn = originalConsoleWarn;
+  console.error = originalConsoleError;
+});
+
+describe("Lifecycle Handlers", () => {
+  describe("onOpen - Multiple Handlers", () => {
+    it("should execute all registered onOpen handlers in order", () => {
+      const router = new WebSocketRouter();
+      const executionOrder: number[] = [];
+
+      // Register multiple handlers
+      router.onOpen(() => {
+        executionOrder.push(1);
+      });
+
+      router.onOpen(() => {
+        executionOrder.push(2);
+      });
+
+      router.onOpen(() => {
+        executionOrder.push(3);
+      });
+
+      // Get the WebSocket handler
+      const wsHandler = router.websocket;
+
+      // Create a mock WebSocket
+      const mockWs = {
+        data: { clientId: "test-123" },
+        send: mock(() => {}),
+        publish: mock(() => {}),
+        subscribe: mock(() => {}),
+        unsubscribe: mock(() => {}),
+      };
+
+      // Trigger the open handler
+      wsHandler.open?.(mockWs as any);
+
+      // Verify all handlers were called in order
+      expect(executionOrder).toEqual([1, 2, 3]);
+    });
+
+    it("should isolate errors in onOpen handlers", () => {
+      const router = new WebSocketRouter();
+      const handler1Called = mock(() => {});
+      const handler2Called = mock(() => {});
+      const handler3Called = mock(() => {});
+
+      // Register handlers where second one throws
+      router.onOpen(() => {
+        handler1Called();
+      });
+
+      router.onOpen(() => {
+        handler2Called();
+        throw new Error("Handler 2 error");
+      });
+
+      router.onOpen(() => {
+        handler3Called();
+      });
+
+      const wsHandler = router.websocket;
+      const mockWs = {
+        data: { clientId: "test-123" },
+        send: mock(() => {}),
+      };
+
+      // Trigger the open handler
+      wsHandler.open?.(mockWs as any);
+
+      // Verify all handlers were attempted despite error in handler 2
+      expect(handler1Called).toHaveBeenCalledTimes(1);
+      expect(handler2Called).toHaveBeenCalledTimes(1);
+      expect(handler3Called).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle async onOpen handlers", async () => {
+      const router = new WebSocketRouter();
+      const executionOrder: number[] = [];
+
+      router.onOpen(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        executionOrder.push(1);
+      });
+
+      router.onOpen(() => {
+        executionOrder.push(2);
+      });
+
+      const wsHandler = router.websocket;
+      const mockWs = {
+        data: { clientId: "test-123" },
+        send: mock(() => {}),
+      };
+
+      wsHandler.open?.(mockWs as any);
+
+      // Handler 2 executes immediately (fire-and-forget for async)
+      expect(executionOrder).toEqual([2]);
+
+      // Wait for async handler to complete
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(executionOrder).toEqual([2, 1]);
+    });
+
+    it("should provide send function in onOpen context", () => {
+      const router = new WebSocketRouter();
+      let sendFunctionProvided = false;
+
+      const WelcomeMessage = messageSchema("WELCOME", {
+        text: z.string(),
+      });
+
+      router.onOpen((ctx) => {
+        sendFunctionProvided = typeof ctx.send === "function";
+        // Test that send can be called
+        ctx.send(WelcomeMessage, { text: "Welcome!" });
+      });
+
+      const wsHandler = router.websocket;
+      const mockWs = {
+        data: { clientId: "test-123" },
+        send: mock(() => {}),
+      };
+
+      wsHandler.open?.(mockWs as any);
+
+      expect(sendFunctionProvided).toBe(true);
+      expect(mockWs.send).toHaveBeenCalled();
+    });
+  });
+
+  describe("onClose - Multiple Handlers", () => {
+    it("should execute all registered onClose handlers in order", () => {
+      const router = new WebSocketRouter();
+      const executionOrder: number[] = [];
+
+      // Register multiple handlers
+      router.onClose(() => {
+        executionOrder.push(1);
+      });
+
+      router.onClose(() => {
+        executionOrder.push(2);
+      });
+
+      router.onClose(() => {
+        executionOrder.push(3);
+      });
+
+      const wsHandler = router.websocket;
+      const mockWs = {
+        data: { clientId: "test-123" },
+        send: mock(() => {}),
+      };
+
+      // Trigger the close handler
+      wsHandler.close?.(mockWs as any, 1000, "Normal closure");
+
+      // Verify all handlers were called in order
+      expect(executionOrder).toEqual([1, 2, 3]);
+    });
+
+    it("should isolate errors in onClose handlers", () => {
+      const router = new WebSocketRouter();
+      const handler1Called = mock(() => {});
+      const handler2Called = mock(() => {});
+      const handler3Called = mock(() => {});
+
+      router.onClose(() => {
+        handler1Called();
+      });
+
+      router.onClose(() => {
+        handler2Called();
+        throw new Error("Handler 2 error");
+      });
+
+      router.onClose(() => {
+        handler3Called();
+      });
+
+      const wsHandler = router.websocket;
+      const mockWs = {
+        data: { clientId: "test-123" },
+        send: mock(() => {}),
+      };
+
+      wsHandler.close?.(mockWs as any, 1000, "Normal closure");
+
+      // Verify all handlers were attempted despite error in handler 2
+      expect(handler1Called).toHaveBeenCalledTimes(1);
+      expect(handler2Called).toHaveBeenCalledTimes(1);
+      expect(handler3Called).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle async onClose handlers", async () => {
+      const router = new WebSocketRouter();
+      const executionOrder: number[] = [];
+
+      router.onClose(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        executionOrder.push(1);
+      });
+
+      router.onClose(() => {
+        executionOrder.push(2);
+      });
+
+      const wsHandler = router.websocket;
+      const mockWs = {
+        data: { clientId: "test-123" },
+        send: mock(() => {}),
+      };
+
+      wsHandler.close?.(mockWs as any, 1000, "Normal closure");
+
+      // Handler 2 executes immediately (fire-and-forget for async)
+      expect(executionOrder).toEqual([2]);
+
+      // Wait for async handler to complete
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(executionOrder).toEqual([2, 1]);
+    });
+
+    it("should provide all context fields in onClose", () => {
+      const router = new WebSocketRouter();
+      let contextFields: {
+        hasWs: boolean;
+        hasCode: boolean;
+        hasReason: boolean;
+        hasSend: boolean;
+        code?: number;
+        reason?: string;
+      } = {
+        hasWs: false,
+        hasCode: false,
+        hasReason: false,
+        hasSend: false,
+      };
+
+      router.onClose((ctx) => {
+        contextFields = {
+          hasWs: !!ctx.ws,
+          hasCode: typeof ctx.code === "number",
+          hasReason: typeof ctx.reason === "string",
+          hasSend: typeof ctx.send === "function",
+          code: ctx.code,
+          reason: ctx.reason,
+        };
+      });
+
+      const wsHandler = router.websocket;
+      const mockWs = {
+        data: { clientId: "test-123" },
+        send: mock(() => {}),
+      };
+
+      wsHandler.close?.(mockWs as any, 1000, "Normal closure");
+
+      expect(contextFields.hasWs).toBe(true);
+      expect(contextFields.hasCode).toBe(true);
+      expect(contextFields.hasReason).toBe(true);
+      expect(contextFields.hasSend).toBe(true);
+      expect(contextFields.code).toBe(1000);
+      expect(contextFields.reason).toBe("Normal closure");
+    });
+
+    it("should provide send function for broadcasting in onClose", () => {
+      const router = new WebSocketRouter();
+      let canUseSend = false;
+
+      const DisconnectMessage = messageSchema("USER_DISCONNECTED", {
+        clientId: z.string(),
+      });
+
+      router.onClose((ctx) => {
+        // Send function should be available for broadcasting
+        // (even though you can't send to the closed connection itself)
+        canUseSend = typeof ctx.send === "function";
+        ctx.send(DisconnectMessage, { clientId: ctx.ws.data.clientId });
+      });
+
+      const wsHandler = router.websocket;
+      const mockWs = {
+        data: { clientId: "test-123" },
+        send: mock(() => {}),
+      };
+
+      wsHandler.close?.(mockWs as any, 1000, "Normal closure");
+
+      expect(canUseSend).toBe(true);
+    });
+  });
+
+  describe("Combined onOpen and onClose", () => {
+    it("should maintain separate handler arrays for open and close", () => {
+      const router = new WebSocketRouter();
+      const openCalled = mock(() => {});
+      const closeCalled = mock(() => {});
+
+      router.onOpen(() => openCalled());
+      router.onClose(() => closeCalled());
+
+      const wsHandler = router.websocket;
+      const mockWs = {
+        data: { clientId: "test-123" },
+        send: mock(() => {}),
+      };
+
+      // Trigger open
+      wsHandler.open?.(mockWs as any);
+      expect(openCalled).toHaveBeenCalledTimes(1);
+      expect(closeCalled).toHaveBeenCalledTimes(0);
+
+      // Trigger close
+      wsHandler.close?.(mockWs as any, 1000, "Normal closure");
+      expect(openCalled).toHaveBeenCalledTimes(1);
+      expect(closeCalled).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/types/client-inference.test.ts
+++ b/test/types/client-inference.test.ts
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2025-present Kriasoft
+// SPDX-License-Identifier: MIT
+
+/**
+ * Type-level tests for typed client adapters (ADR-002).
+ * Validates full type inference in handlers, send, and request methods.
+ *
+ * @see specs/adrs.md#ADR-002 - Type override implementation
+ * @see specs/testing.md#client-type-inference - Test requirements
+ */
+
+import { expectTypeOf, test } from "bun:test";
+import { z } from "zod";
+import * as v from "valibot";
+import { createMessageSchema as createZodSchema } from "../../zod/index.js";
+import { createMessageSchema as createValibotSchema } from "../../valibot/index.js";
+import { createClient as createZodClient } from "../../zod/client.js";
+import { createClient as createValibotClient } from "../../valibot/client.js";
+import { createClient as createGenericClient } from "../../client/index.js";
+
+// Zod schemas for testing
+const { messageSchema: zodMessageSchema } = createZodSchema(z);
+const ZodJoinRoomOK = zodMessageSchema("JOIN_ROOM_OK", { roomId: z.string() });
+const ZodNoPayload = zodMessageSchema("NO_PAYLOAD");
+const ZodRequest = zodMessageSchema("REQ", { id: z.number() });
+const ZodReply = zodMessageSchema("REPLY", { result: z.boolean() });
+const ZodRoomMsg = zodMessageSchema(
+  "CHAT",
+  { text: z.string() },
+  { roomId: z.string() }, // Required meta
+);
+const ZodOptionalMeta = zodMessageSchema(
+  "NOTIFY",
+  { text: z.string() },
+  { priority: z.enum(["low", "high"]).optional() },
+);
+
+// Valibot schemas for testing
+const { messageSchema: valibotMessageSchema } = createValibotSchema(v);
+const ValibotJoinRoomOK = valibotMessageSchema("JOIN_ROOM_OK", {
+  roomId: v.string(),
+});
+const ValibotNoPayload = valibotMessageSchema("NO_PAYLOAD");
+const ValibotRequest = valibotMessageSchema("REQ", { id: v.number() });
+const ValibotReply = valibotMessageSchema("REPLY", { result: v.boolean() });
+
+// ============================================================================
+// Zod Client Type Tests
+// ============================================================================
+
+test("Zod: on() handler receives fully typed message", () => {
+  const client = createZodClient({ url: "ws://test" });
+
+  client.on(ZodJoinRoomOK, (msg) => {
+    // ✅ Positive: msg fully typed
+    expectTypeOf(msg).toEqualTypeOf<{
+      type: "JOIN_ROOM_OK";
+      meta: { timestamp?: number; correlationId?: string };
+      payload: { roomId: string };
+    }>();
+    expectTypeOf(msg.payload.roomId).toBeString();
+    expectTypeOf(msg.type).toEqualTypeOf<"JOIN_ROOM_OK">();
+    expectTypeOf(msg.meta.timestamp).toEqualTypeOf<number | undefined>();
+  });
+});
+
+test("Zod: on() handler has no payload access for no-payload schema", () => {
+  const client = createZodClient({ url: "ws://test" });
+
+  client.on(ZodNoPayload, (msg) => {
+    expectTypeOf(msg.type).toEqualTypeOf<"NO_PAYLOAD">();
+    expectTypeOf(msg.meta).not.toBeUnknown();
+
+    // @ts-expect-error - payload should not exist
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    msg.payload;
+  });
+});
+
+test("Zod: request() returns typed promise (with payload)", () => {
+  const client = createZodClient({ url: "ws://test" });
+
+  const promise = client.request(ZodRequest, { id: 42 }, ZodReply);
+
+  // ✅ reply fully typed
+  expectTypeOf(promise).toEqualTypeOf<
+    Promise<{
+      type: "REPLY";
+      meta: { timestamp?: number; correlationId?: string };
+      payload: { result: boolean };
+    }>
+  >();
+});
+
+test("Zod: request() without payload for no-payload schema", () => {
+  const client = createZodClient({ url: "ws://test" });
+
+  // Type-only check: request() with no-payload schema omits payload param
+  type RequestCall = ReturnType<
+    typeof client.request<typeof ZodNoPayload, typeof ZodReply>
+  >;
+
+  expectTypeOf<RequestCall>().toEqualTypeOf<
+    Promise<{
+      type: "REPLY";
+      meta: { timestamp?: number; correlationId?: string };
+      payload: { result: boolean };
+    }>
+  >();
+});
+
+test("Zod: extended meta with required fields", () => {
+  const client = createZodClient({ url: "ws://test" });
+
+  // RoomMsg has required meta.roomId field
+  client.on(ZodRoomMsg, (msg) => {
+    expectTypeOf(msg.meta.roomId).toBeString();
+    expectTypeOf(msg.payload.text).toBeString();
+  });
+});
+
+test("Zod: extended meta with optional fields", () => {
+  const client = createZodClient({ url: "ws://test" });
+
+  // OptionalMeta has optional meta.priority field
+  client.on(ZodOptionalMeta, (msg) => {
+    expectTypeOf(msg.meta.priority).toEqualTypeOf<"low" | "high" | undefined>();
+    expectTypeOf(msg.payload.text).toBeString();
+  });
+});
+
+test("Zod: send() with optional meta (priority field)", () => {
+  const client = createZodClient({ url: "ws://test" });
+
+  // Type-level validation: send() accepts optional meta with priority field
+  // Since ZodOptionalMeta has payload, it uses the 3-param overload:
+  // send(schema, payload, opts?)
+
+  // Verify the method signature accepts optional meta
+  client.send(
+    ZodOptionalMeta,
+    { text: "test" },
+    { meta: { priority: "high" } },
+  );
+
+  client.send(
+    ZodOptionalMeta,
+    { text: "test" },
+    { meta: {} }, // priority is optional
+  );
+
+  client.send(
+    ZodOptionalMeta,
+    { text: "test" },
+    // opts entirely optional
+  );
+});
+
+// ============================================================================
+// Valibot Client Type Tests
+// ============================================================================
+
+// Note: Valibot runtime tests require client support for Valibot schema type extraction
+// These are type-only validation tests that confirm the type system works correctly
+
+test("Valibot: type inference works at compile time", () => {
+  const client = createValibotClient({ url: "ws://test" });
+
+  // Type-only check: handler parameter should be typed
+  type HandlerMsg = Parameters<
+    Parameters<typeof client.on<typeof ValibotJoinRoomOK>>[1]
+  >[0];
+
+  expectTypeOf<HandlerMsg>().toEqualTypeOf<{
+    type: "JOIN_ROOM_OK";
+    meta: { timestamp?: number; correlationId?: string };
+    payload: { roomId: string };
+  }>();
+});
+
+test("Valibot: no-payload schema type inference", () => {
+  const client = createValibotClient({ url: "ws://test" });
+
+  // Type-only check: no-payload handler has no payload field
+  type HandlerMsg = Parameters<
+    Parameters<typeof client.on<typeof ValibotNoPayload>>[1]
+  >[0];
+
+  expectTypeOf<HandlerMsg>().toEqualTypeOf<{
+    type: "NO_PAYLOAD";
+    meta: { timestamp?: number; correlationId?: string };
+  }>();
+});
+
+test("Valibot: request() without payload for no-payload schema", () => {
+  const ValibotRequest = valibotMessageSchema("REQ_NO_PAYLOAD");
+  const ValibotReply = valibotMessageSchema("REPLY", { result: v.boolean() });
+
+  const client = createValibotClient({ url: "ws://test" });
+
+  // Type-only check: request() with no-payload schema omits payload param
+  type RequestCall = ReturnType<
+    typeof client.request<typeof ValibotRequest, typeof ValibotReply>
+  >;
+  type ReplyType = Awaited<RequestCall>;
+
+  // Reply includes full message structure (type, meta, payload)
+  expectTypeOf<ReplyType>().toMatchTypeOf<{
+    type: "REPLY";
+    payload: { result: boolean };
+  }>();
+});
+
+// ============================================================================
+// Generic Client Type Tests (Fallback Behavior)
+// ============================================================================
+
+test("Generic client: handlers receive unknown (no type inference)", () => {
+  const client = createGenericClient({ url: "ws://test" });
+
+  client.on(ZodJoinRoomOK, (msg) => {
+    // ⚠️ msg is unknown in generic client
+    expectTypeOf(msg).toBeUnknown();
+
+    // Manual type assertion required
+    const typed = msg as { type: string; payload: { roomId: string } };
+    expectTypeOf(typed.payload.roomId).toBeString();
+  });
+});
+
+// ============================================================================
+// Cross-Validator Compatibility Tests
+// ============================================================================
+
+test("Typed clients provide better inference than generic client", () => {
+  const zodClient = createZodClient({ url: "ws://test" });
+  const genericClient = createGenericClient({ url: "ws://test" });
+
+  // Zod client: handler infers message type
+  zodClient.on(ZodJoinRoomOK, (msg) => {
+    expectTypeOf(msg).not.toBeUnknown();
+    expectTypeOf(msg.payload.roomId).toBeString();
+  });
+
+  // Generic client: handler receives unknown
+  genericClient.on(ZodJoinRoomOK, (msg) => {
+    expectTypeOf(msg).toBeUnknown();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
+    "downlevelIteration": true,
 
     // Some stricter flags (disabled by default)
     "noUnusedLocals": false,

--- a/valibot/client.ts
+++ b/valibot/client.ts
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2025-present Kriasoft
+// SPDX-License-Identifier: MIT
+
+/**
+ * Typed WebSocket client adapter for Valibot schemas.
+ *
+ * Provides full type inference for message handlers via type override pattern (ADR-002).
+ * Zero runtime overhead - pure type-level wrapper around generic client.
+ *
+ * @see specs/adrs.md#ADR-002 - Type override rationale
+ * @see specs/client.md - Client API specification
+ */
+
+import { createClient as createGenericClient } from "../client/index.js";
+import type {
+  AnyInboundMessage,
+  ClientOptions,
+  ClientState,
+  WebSocketClient,
+} from "../client/types.js";
+import type {
+  InferMessage,
+  InferMeta,
+  InferPayload,
+  MessageSchemaType as ValibotMessageSchema,
+} from "./types.js";
+
+// Re-export base types and error classes
+export * from "../client/types.js";
+export type {
+  InferMessage,
+  InferMeta,
+  InferPayload,
+  MessageSchemaType as ValibotMessageSchema,
+} from "./types.js";
+
+/**
+ * Options for send() method with typed meta field inference.
+ */
+interface SendOptions<S extends ValibotMessageSchema> {
+  meta?: InferMeta<S>;
+  correlationId?: string;
+}
+
+/**
+ * Options for request() method with typed meta field inference.
+ */
+interface RequestOptions<S extends ValibotMessageSchema>
+  extends SendOptions<S> {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Typed WebSocket client interface with Valibot schema inference.
+ *
+ * Overrides generic client methods to provide full type safety:
+ * - on(): Handler receives InferMessage<S> (typed msg with payload/meta)
+ * - send(): Payload conditional typing via overloads
+ * - request(): Returns Promise<InferMessage<R>>
+ *
+ * @see specs/adrs.md#ADR-002 - Type override implementation pattern
+ */
+export interface ValibotWebSocketClient
+  extends Omit<WebSocketClient, "on" | "send" | "request"> {
+  readonly state: ClientState;
+  readonly isConnected: boolean;
+  readonly protocol: string;
+
+  connect(): Promise<void>;
+  close(opts?: { code?: number; reason?: string }): Promise<void>;
+
+  onState(cb: (state: ClientState) => void): () => void;
+  onceOpen(): Promise<void>;
+
+  /**
+   * Register typed message handler.
+   * Handler receives fully typed message inferred from schema.
+   */
+  on<S extends ValibotMessageSchema>(
+    schema: S,
+    handler: (msg: InferMessage<S>) => void,
+  ): () => void;
+
+  /**
+   * Send message with payload (schema defines payload field).
+   * Payload type inferred from schema, required at compile time.
+   */
+  send<S extends ValibotMessageSchema>(
+    schema: S,
+    payload: InferPayload<S>,
+    opts?: SendOptions<S>,
+  ): InferPayload<S> extends never ? never : boolean;
+
+  /**
+   * Send message without payload (schema has no payload field).
+   * Payload parameter omitted at compile time.
+   */
+  send<S extends ValibotMessageSchema>(
+    schema: S,
+    opts?: SendOptions<S>,
+  ): InferPayload<S> extends never ? boolean : never;
+
+  /**
+   * Request/response with typed reply (with payload).
+   * Payload type inferred from schema, required at compile time.
+   */
+  request<S extends ValibotMessageSchema, R extends ValibotMessageSchema>(
+    schema: S,
+    payload: InferPayload<S>,
+    reply: R,
+    opts?: RequestOptions<S>,
+  ): InferPayload<S> extends never ? never : Promise<InferMessage<R>>;
+
+  /**
+   * Request/response with typed reply (no payload).
+   * Payload parameter omitted at compile time.
+   */
+  request<S extends ValibotMessageSchema, R extends ValibotMessageSchema>(
+    schema: S,
+    reply: R,
+    opts?: RequestOptions<S>,
+  ): InferPayload<S> extends never ? Promise<InferMessage<R>> : never;
+
+  /**
+   * Hook for unhandled message types.
+   * Receives structurally valid messages with no registered schema.
+   */
+  onUnhandled(cb: (msg: AnyInboundMessage) => void): () => void;
+
+  /**
+   * Hook for non-fatal internal errors.
+   * Fires for: parse failures, validation failures, queue overflow.
+   */
+  onError(
+    cb: (
+      error: Error,
+      context: {
+        type: "parse" | "validation" | "overflow" | "unknown";
+        details?: unknown;
+      },
+    ) => void,
+  ): () => void;
+}
+
+/**
+ * Create typed WebSocket client with Valibot schema inference.
+ *
+ * Pure type cast - zero runtime overhead compared to generic client.
+ * All type safety is compile-time only via TypeScript inference.
+ *
+ * @example
+ * ```typescript
+ * import * as v from "valibot";
+ * import { createMessageSchema } from "bun-ws-router/valibot";
+ * import { createClient } from "bun-ws-router/valibot/client";
+ *
+ * const { messageSchema } = createMessageSchema(v);
+ * const HelloOk = messageSchema("HELLO_OK", { text: v.string() });
+ *
+ * const client = createClient({ url: "wss://api.example.com" });
+ *
+ * client.on(HelloOk, (msg) => {
+ *   // ✅ msg fully typed: { type: "HELLO_OK", meta: {...}, payload: { text: string } }
+ *   console.log(msg.payload.text.toUpperCase());
+ * });
+ * ```
+ *
+ * @see specs/client.md - Full client API documentation
+ * @see specs/adrs.md#ADR-002 - Type override implementation details
+ */
+export function createClient(opts: ClientOptions): ValibotWebSocketClient {
+  return createGenericClient(opts) as ValibotWebSocketClient;
+}

--- a/zod/client.ts
+++ b/zod/client.ts
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2025-present Kriasoft
+// SPDX-License-Identifier: MIT
+
+/**
+ * Typed WebSocket client adapter for Zod schemas.
+ *
+ * Provides full type inference for message handlers via type override pattern (ADR-002).
+ * Zero runtime overhead - pure type-level wrapper around generic client.
+ *
+ * @see specs/adrs.md#ADR-002 - Type override rationale
+ * @see specs/client.md - Client API specification
+ */
+
+import { createClient as createGenericClient } from "../client/index.js";
+import type {
+  AnyInboundMessage,
+  ClientOptions,
+  ClientState,
+  WebSocketClient,
+} from "../client/types.js";
+import type {
+  InferMessage,
+  InferMeta,
+  InferPayload,
+  MessageSchemaType as ZodMessageSchema,
+} from "./types.js";
+
+// Re-export base types and error classes
+export * from "../client/types.js";
+export type {
+  InferMessage,
+  InferMeta,
+  InferPayload,
+  MessageSchemaType as ZodMessageSchema,
+} from "./types.js";
+
+/**
+ * Options for send() method with typed meta field inference.
+ */
+interface SendOptions<S extends ZodMessageSchema> {
+  meta?: InferMeta<S>;
+  correlationId?: string;
+}
+
+/**
+ * Options for request() method with typed meta field inference.
+ */
+interface RequestOptions<S extends ZodMessageSchema> extends SendOptions<S> {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Typed WebSocket client interface with Zod schema inference.
+ *
+ * Overrides generic client methods to provide full type safety:
+ * - on(): Handler receives InferMessage<S> (typed msg with payload/meta)
+ * - send(): Payload conditional typing via overloads
+ * - request(): Returns Promise<InferMessage<R>>
+ *
+ * @see specs/adrs.md#ADR-002 - Type override implementation pattern
+ */
+export interface ZodWebSocketClient
+  extends Omit<WebSocketClient, "on" | "send" | "request"> {
+  readonly state: ClientState;
+  readonly isConnected: boolean;
+  readonly protocol: string;
+
+  connect(): Promise<void>;
+  close(opts?: { code?: number; reason?: string }): Promise<void>;
+
+  onState(cb: (state: ClientState) => void): () => void;
+  onceOpen(): Promise<void>;
+
+  /**
+   * Register typed message handler.
+   * Handler receives fully typed message inferred from schema.
+   */
+  on<S extends ZodMessageSchema>(
+    schema: S,
+    handler: (msg: InferMessage<S>) => void,
+  ): () => void;
+
+  /**
+   * Send message with payload (schema defines payload field).
+   * Payload type inferred from schema, required at compile time.
+   */
+  send<S extends ZodMessageSchema>(
+    schema: S,
+    payload: InferPayload<S>,
+    opts?: SendOptions<S>,
+  ): InferPayload<S> extends never ? never : boolean;
+
+  /**
+   * Send message without payload (schema has no payload field).
+   * Payload parameter omitted at compile time.
+   */
+  send<S extends ZodMessageSchema>(
+    schema: S,
+    opts?: SendOptions<S>,
+  ): InferPayload<S> extends never ? boolean : never;
+
+  /**
+   * Request/response with typed reply (with payload).
+   * Payload type inferred from schema, required at compile time.
+   */
+  request<S extends ZodMessageSchema, R extends ZodMessageSchema>(
+    schema: S,
+    payload: InferPayload<S>,
+    reply: R,
+    opts?: RequestOptions<S>,
+  ): InferPayload<S> extends never ? never : Promise<InferMessage<R>>;
+
+  /**
+   * Request/response with typed reply (no payload).
+   * Payload parameter omitted at compile time.
+   */
+  request<S extends ZodMessageSchema, R extends ZodMessageSchema>(
+    schema: S,
+    reply: R,
+    opts?: RequestOptions<S>,
+  ): InferPayload<S> extends never ? Promise<InferMessage<R>> : never;
+
+  /**
+   * Hook for unhandled message types.
+   * Receives structurally valid messages with no registered schema.
+   */
+  onUnhandled(cb: (msg: AnyInboundMessage) => void): () => void;
+
+  /**
+   * Hook for non-fatal internal errors.
+   * Fires for: parse failures, validation failures, queue overflow.
+   */
+  onError(
+    cb: (
+      error: Error,
+      context: {
+        type: "parse" | "validation" | "overflow" | "unknown";
+        details?: unknown;
+      },
+    ) => void,
+  ): () => void;
+}
+
+/**
+ * Create typed WebSocket client with Zod schema inference.
+ *
+ * Pure type cast - zero runtime overhead compared to generic client.
+ * All type safety is compile-time only via TypeScript inference.
+ *
+ * @example
+ * ```typescript
+ * import { z } from "zod";
+ * import { createMessageSchema } from "bun-ws-router/zod";
+ * import { createClient } from "bun-ws-router/zod/client";
+ *
+ * const { messageSchema } = createMessageSchema(z);
+ * const HelloOk = messageSchema("HELLO_OK", { text: z.string() });
+ *
+ * const client = createClient({ url: "wss://api.example.com" });
+ *
+ * client.on(HelloOk, (msg) => {
+ *   // ✅ msg fully typed: { type: "HELLO_OK", meta: {...}, payload: { text: string } }
+ *   console.log(msg.payload.text.toUpperCase());
+ * });
+ * ```
+ *
+ * @see specs/client.md - Full client API documentation
+ * @see specs/adrs.md#ADR-002 - Type override implementation details
+ */
+export function createClient(opts: ClientOptions): ZodWebSocketClient {
+  return createGenericClient(opts) as ZodWebSocketClient;
+}


### PR DESCRIPTION
## Summary

Introduces typed client adapters (`/zod/client`, `/valibot/client`) that provide **automatic type inference** in message handlers, eliminating manual type assertions. Handlers now receive fully typed messages with literal type names, typed payloads, and typed meta fields — no more `unknown` types.

Also fixes cross-adapter type consistency and includes documentation improvements.

### What Changed

- **Typed clients**: New `/zod/client` and `/valibot/client` entry points with full inference in `.on()`, `.send()`, and `.request()` methods
- **Zero runtime cost**: Pure type-level wrappers using type override pattern (ADR-002)
- **Type consistency**: Standardized type definitions across Zod/Valibot adapters
- **Improved handler contexts**: `onClose()` now uses structured `CloseHandlerContext<TData>` for consistency with `onMessage()`
- **Documentation**: Enhanced VitePress config, comprehensive typed client usage examples
- **Version**: Bump to `0.6.0`

### Why

The generic client (`/client`) provided no type inference — handlers received `unknown`, requiring manual type assertions for every message. The new typed adapters leverage TypeScript's inference to provide full type safety at compile time with zero runtime overhead.

## Migration Guide: v0.5.0 → v0.6.0

### Breaking Changes

#### Client Import Paths (Typed Inference)

**Before (v0.5.0):**

```typescript
import { createClient } from "bun-ws-router/client";

const client = createClient({ url: "wss://api.example.com" });

client.on(HelloOk, (msg) => {
  // ⚠️ msg was `unknown` - required manual type assertions
  const typed = msg as InferMessage<typeof HelloOk>;
  console.log(typed.payload.text);
});
```

**After (v0.6.0):**

```typescript
// Use typed client for automatic inference
import { createClient } from "bun-ws-router/zod/client";
// or
import { createClient } from "bun-ws-router/valibot/client";

const client = createClient({ url: "wss://api.example.com" });

client.on(HelloOk, (msg) => {
  // ✅ msg fully typed automatically - no assertions needed
  console.log(msg.payload.text); // Type: string
  console.log(msg.type); // Type: "HELLO_OK" (literal)
  console.log(msg.meta.timestamp); // Type: number | undefined
});
```

**Generic client remains available** for custom validators at `/client` (unchanged behavior):

```typescript
// Only if implementing custom validator
import { createClient } from "bun-ws-router/client";
```

### Non-Breaking Improvements

- **Payload conditional typing**: Overloads now enforce payload presence/absence at compile time
- **Extended meta inference**: Required vs optional meta fields fully typed
- **Request/response typing**: Reply messages automatically inferred in `request()` calls
- **Type consistency**: `correlationId` standardized as `string` across all type definitions (no runtime change)

### Recommended Actions

1. **Update client imports** to use typed adapters for better DX:

   ```diff
   - import { createClient } from "bun-ws-router/client";
   + import { createClient } from "bun-ws-router/zod/client";
   ```

2. **Remove manual type assertions** - no longer needed with typed clients:

   ```diff
   client.on(HelloOk, (msg) => {
   -   const typed = msg as InferMessage<typeof HelloOk>;
   -   console.log(typed.payload.text);
   +   console.log(msg.payload.text); // Auto-typed!
   });
   ```

3. **Use string correlation IDs** for consistency (recommended, not required):

   ```typescript
   // ✅ Preferred: UUIDs for uniqueness
   client.request(schema, payload, replySchema, {
     correlationId: crypto.randomUUID(),
   });
   ```

### Detailed Changes

See [specs/adrs.md#ADR-002](../blob/main/specs/adrs.md#adr-002-typed-client-adapters-via-type-overrides) for type override pattern rationale.
